### PR TITLE
[Fix #206] Use secure websocket

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -6,7 +6,7 @@
  */
 
 // Temp dev solution
-var MAKEDRIVE_URL = 'wss://makedrive.alicoding.com?username=wmobiledev';
+var MAKEDRIVE_URL = 'wss://makedrive.herokuapp.com?username=wmobiledev';
 
 var MakeDrive = require('makedrive');
 var watch = require('watchjs').watch;


### PR DESCRIPTION
we need to use the `herokuapp` url for ssl
