### PR TITLE
multiline support for the text block

### DIFF
--- a/blocks/text/index.js
+++ b/blocks/text/index.js
@@ -21,5 +21,27 @@ module.exports = {
                 value: '14'
             }
         }
+    },
+    // If we have multi-line text content, split it over several
+    // paragraphs, preserving the user-intended line breaks.
+    attached: function() {
+        var data = this.$data.attributes.innerHTML.value;
+        if (!!data) {
+            data = data.trim();
+            if(data.indexOf("\n") > -1) {
+                var chunks = data.split("\n");
+                this.$el.innerHTML = "";
+                chunks.forEach(function(chunk) {
+                    var p = document.createElement("p");
+                    if (!!chunk) {
+                        p.textContent = chunk;
+                    }
+                    else {
+                        p.innerHTML = "&nbsp;"
+                    }
+                    this.$el.appendChild(p);
+                }.bind(this));
+            }
+        }
     }
 };


### PR DESCRIPTION
Fixes #247. The text block now checks whether the data it needs to show should be fit over multiple lines. If so, the text is chopped up, and each line is given its own `<p>` element. 
