### PR TITLE
Bug291 fixed fixed line height for accent aigu above the E...

### DIFF
--- a/views/ftu/index.less
+++ b/views/ftu/index.less
@@ -12,7 +12,7 @@
         padding: 20px;
         margin: 0;
         font-size: 110px;
-        line-height: 105px;
+        line-height: 115px;
         text-transform: uppercase;
 
         > span {
@@ -25,7 +25,7 @@
         position: absolute;
         width: 90%;
         height: 10px;
-        top: 430px;
+        top: 480px;
         margin-left: 5%;
 
         background-color: @white;


### PR DESCRIPTION
...and moved line down for better spacing.

In order to fix the "Applications" text from going off of the screen:
I looked through the other language files and determined that this is the only (romance) language, so far, that does not use the shortened word, "App."  
I read that we are only supposed to make changes in the .json file - I did that but I still needed to make changes in three other files.
Also, all four of these files (including the .json file) are in my .gitignore - so thought I'd check in before pushing up changes to files in .gitignore.
Here are the list of files that when I replaced the "Applications créées par" to "Apps créées par" , things looked better:

In order to make this change, I had to edit four files:
webmaker-app/build/index.js - line 1977
webmaker-app/build/publish-assets/index.js - line 471 
webmaker-app/locale/index.js - line 1
webmaker-app/locale/fr/mobile-appmaker.json - line 183

Also (again), if we are using a typical iPhone 5 screen - 320 x 568 - the "créées" is still off of the edge of the screen.  So, it depends on the size of the test screen?
