### PR TITLE
Fix for template picker that makes entire square clickable / tappable.

### DIFF
--- a/components/templateCell/index.less
+++ b/components/templateCell/index.less
@@ -30,7 +30,7 @@
         display: block;
         width: 70px;
         height: 70px;
-        margin: 0px auto 8px auto;
+        margin: 0 auto 8px auto;
     }
 
     .name {


### PR DESCRIPTION
STT (steps to test)
- Open the Template Picker page "/template"
- Click along the top edge of any of the template tiles

Before: Nothing happens, tops aren't clickable
After: Template is chosen and editor opens

Fixes #339 
