### PR TITLE
Padding fixes for Profile / Discover / Templates pages

### DIFF
--- a/components/tabBar/index.less
+++ b/components/tabBar/index.less
@@ -4,7 +4,7 @@
     bottom: 0;
 
     width: 100%;
-    height: @footer-height;
+    height: @tabBar-height;
     border-top: 1px solid @lightGrey;
     background-color: @white;
 }

--- a/static/styles/variables.less
+++ b/static/styles/variables.less
@@ -1,6 +1,8 @@
 @fonts-path: '/fonts';
 @header-height: 50px;
 @footer-height: 70px;
+@tabBar-height: 46px;
+
 
 /*********************************************************
 * Typography

--- a/views/discover/index.less
+++ b/views/discover/index.less
@@ -1,3 +1,7 @@
+#discover {
+    padding: 50px 0 @tabBar-height 0;
+}
+
 #discover ul {
     margin: 0 0 @header-height 0; //Bottom margin as much as bottom tabbar.
     padding: 0;

--- a/views/profile/index.less
+++ b/views/profile/index.less
@@ -1,5 +1,5 @@
 #profile {
-    .header-space;
+    padding: 50px 0 @tabBar-height 0;
 
     input {
         color: @black;

--- a/views/templates/index.less
+++ b/views/templates/index.less
@@ -1,5 +1,5 @@
 #templates {
-    .header-space;
+    padding: 50px 0 @tabBar-height 0;
 }
 
 #templates ul {


### PR DESCRIPTION
The toggle button on the bottom of the Edit & Preview pages is taller than the tabBar, but we were using the same bottom padding on all pages, which was breaking the profile / discover / templates page layout.

STT
- Load up template page
- Tab bar 46px tall
- There is no gray space below the bottom of the template squares
