### PR TITLE
Updated ui to change account email on sign up

### DIFF
--- a/locale/en_US/mobile-appmaker.json
+++ b/locale/en_US/mobile-appmaker.json
@@ -259,9 +259,9 @@
       "message": "I agree to your terms and conditions",
       "description": "Label for terms and conditions checkbox"
     },
-    "Choose a different email": {
-      "message": "Choose a different email",
-      "description": "Button for choosing a different email "
+    "Change": {
+      "message": "Change",
+      "description": "Link for changing things, like choosing a different email address for your account"
     },
     "share_message": {
       "message": "Check out the app \"{{app.name}}\" I made with Mozilla Webmaker",

--- a/views/sign-up/index.html
+++ b/views/sign-up/index.html
@@ -1,11 +1,8 @@
 <div v-component="navigationBar"></div>
 
-<div class="form-group">
-    <label for="email">{{ 'Email' | i18n }}</label>
-    <input type="text" id="email" v-model="email">
-    <p>
-        <button class="btn" v-on="click: login">{{ 'Choose a different email' | i18n }}</button>
-    </p>
+<div class="email">
+    <h3>{{ 'Email' | i18n }}</h3>
+    {{ email || 'your@email.com' }} - <a v-on="click: login">{{ 'Change' | i18n }}</a>
 </div>
 
 <form>
@@ -16,7 +13,7 @@
             {{'Sorry, that name has already been snagged! Please try another.' | i18n}}
         </div>
     </div>
-    
+
     <div class="checkbox">
         <label for="mailing-list">
             <input type="checkbox" id="mailing-list" v-model="user.mailingList">

--- a/views/sign-up/index.less
+++ b/views/sign-up/index.less
@@ -1,0 +1,17 @@
+#sign-up {
+    .email {
+        font-size: 14px;
+        padding: 14px;
+        color: #638093;
+
+        h3 {
+            font-size: inherit;
+            margin: 0 0 5px 0;
+            padding: 0;
+        }
+
+        a {
+            cursor: pointer;
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Made email into text instead of input
- Made "change email" button into a link

Closes #394
