### PR TITLE
Nuked spacer div from bottom of templates page

### DIFF
--- a/views/templates/index.html
+++ b/views/templates/index.html
@@ -2,5 +2,4 @@
 <ul>
     <li v-component="templateCell" v-repeat="templates"></li>
 </ul>
-<div class="tab-bar-space">&nbsp;</div>
 <div v-component="tabBar"></div>


### PR DESCRIPTION
Gets rid of the unexpected space here:

![image](https://cloud.githubusercontent.com/assets/25212/4752897/49afcd56-5ab1-11e4-9a02-9e046063140b.png)
