### PR TITLE
Force utf8 encoding when reading JSON file.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -103,7 +103,7 @@ Model.prototype.readFileAsJson = function (filename, options, callback) {
     options = options || {};
     options.defaultData = options.defaultData || {};
 
-    self._fs.readFile(filename, function (err, file) {
+    self._fs.readFile(filename, 'utf8', function (err, file) {
         function onRead(err) {
             if (err) console.log(err);
             // Try parsing it.


### PR DESCRIPTION
When reading a text file (vs. binary) you need to set the encoding manually.  If you don't, multi-byte strings will fail when you try to parse this as JSON.
