### PR TITLE
Editor title bar updates

### DIFF
--- a/locale/en_US/mobile-appmaker.json
+++ b/locale/en_US/mobile-appmaker.json
@@ -55,6 +55,10 @@
         "message": "Name",
         "description": "Label on the profile page, e.g. Name: Kate, Location: Canada"
     },
+    "App Settings": {
+        "message": "App Settings",
+        "description": "Title within app editor for page where user can change the app name and icon"
+    },
     "activists": {
         "message": "activists",
         "description": "To be replaced in the sentence: Apps made by activists"

--- a/views/make/index.html
+++ b/views/make/index.html
@@ -28,5 +28,5 @@
         v-component="dataRepresentation"
         v-with="dataSet : currentDataSets, initialDataLoaded : initialDataLoaded"></div>
 
-    <div v-component="makeBar" v-with="uiMode: mode === 'settings' ? 'edit' : mode, onChange: changeMode"></div>
+    <div v-if="mode !== 'settings'" v-component="makeBar" v-with="uiMode: mode === 'settings' ? 'edit' : mode, onChange: changeMode"></div>
 </div>

--- a/views/make/index.less
+++ b/views/make/index.less
@@ -4,6 +4,12 @@
     .edit-inner {
         padding: 10px;
     }
+
+    .edit-app-name {
+        border-bottom: dashed 1px @turquoise;
+        padding-bottom: 2px;
+    }
+
     .add {
         display: flex;
         justify-content: center;
@@ -16,7 +22,7 @@
 
         background: @highlight;
         color: @white;
-  
+
         text-align: center;
         text-decoration: none;
 
@@ -39,14 +45,14 @@
     > li {
         display: block;
         position: relative;
-        
+
         padding: 10px 0;
         border: 1px dashed transparent;
 
         .draggable-handle {
             display: none;
         }
-        
+
         // Editable state
         transition: margin 0.2s ease-in-out,
             padding 0.2s ease-in-out,

--- a/views/make/navigation.html
+++ b/views/make/navigation.html
@@ -1,11 +1,16 @@
-<button class="back nav-btn" v-on="click: goBack">&lt;</button>
+<a class="nav-btn" v-on="click: goBack">{{ 'Done' | i18n}}</a>
+
 <h1>
-    <span v-if="mode === 'settings'" class="animated fadeIn">{{ 'Settings' | i18n}}</span>
-    <span v-if="mode !== 'settings'" class="animated fadeIn">{{app.name}}</span>
+    <span v-if="mode === 'settings'">{{ 'App Settings' | i18n}}</span>
+    <a class="edit-app-name" v-if="mode === 'edit'" v-on="click: changeMode('settings')" v-if="mode !== 'settings'">
+      {{app.name}}
+      <span class="fa fa-pencil"></span>
+    </a>
+    <span v-if="mode === 'play'">
+      {{app.name}}
+    </span>
 </h1>
-<a class="nav-btn animated fadeIn" v-if="!offlineUser && mode === 'play'" href="{{onDone}}">
+
+<a v-if="mode !== 'settings' && !offlineUser" class="nav-btn" href="{{onDone}}">
     {{ 'Publish' | i18n}}
-</a>
-<button class="nav-btn nav-btn-icon animated fadeIn" v-if="mode === 'edit'" v-on="click: changeMode('settings')">
-    <span class="fa fa-gear"></span>
 </a>

--- a/views/make/settings.html
+++ b/views/make/settings.html
@@ -1,11 +1,8 @@
 <div class="form-group">
     <label for="name">App Name</label>
-    <input id="name" type="text" v-model="app.name" v-on="keyup: updateName(app.name)"> 
+    <input id="name" type="text" v-model="app.name" v-on="keyup: updateName(app.name)">
 </div>
 <div class="form-group" v-if="app.url">
     <label for="url">URL</label>
     <p id="url" class="url">{{app.url}}</p>
-</div>
-<div class="form-group">
-    <a class="btn btn-dark btn-block" href="{{onDone}}">{{ 'Publish' | i18n }}</a>
 </div>


### PR DESCRIPTION
Updates
- Removed 'fadeIn' on title bar between states (not consistent with other parts of app)
- App name now edited via tapping the app name in Edit Mode
- Publish is now it's own action in the title bar in Edit & Preview mode when signed in
- Removed Edit / Preview / Data toggle when in App Settings mode

Fixes #590 
