### PR TITLE
improved text editing for text elements

### DIFF
--- a/www_src/blocks/text.jsx
+++ b/www_src/blocks/text.jsx
@@ -30,10 +30,8 @@ var Text = React.createClass({
   render: function() {
     var style = {};
     var props = this.props;
-    Object.keys(props).forEach(prop => {
-      if (prop === "innerHTML") return;
-      style[prop] = props[prop]
-    });
+    ['fontFamily', 'color', 'fontWeight', 'fontStyle', 'textDecoration', 'textAlign', 'whiteSpace']
+      .forEach(prop => style[prop] = props[prop]);
 
     if (props.position) {
       style = assign(style, utils.propsToPosition(props));

--- a/www_src/blocks/text.jsx
+++ b/www_src/blocks/text.jsx
@@ -12,8 +12,15 @@ var Text = React.createClass({
       fontStyle: 'normal',
       textDecoration: 'none',
       textAlign: 'center',
+      whiteSpace: 'nowrap',
       innerHTML: 'Hello world'
     }
+  },
+
+  getInitialState: function() {
+    return {
+      editing: false
+    };
   },
 
   getDefaultProps: function () {
@@ -23,14 +30,47 @@ var Text = React.createClass({
   render: function() {
     var style = {};
     var props = this.props;
-    ['fontFamily', 'color', 'fontWeight', 'fontStyle', 'textDecoration', 'textAlign']
-      .forEach(prop => style[prop] = props[prop]);
+    Object.keys(props).forEach(prop => {
+      if (prop === "innerHTML") return;
+      style[prop] = props[prop]
+    });
 
     if (props.position) {
       style = assign(style, utils.propsToPosition(props));
     }
 
-    return <p style={style}>{props.innerHTML}</p>;
+    var inputStyle = assign({}, style);
+    inputStyle.background = "transparent";
+    inputStyle.border = "none";
+
+    var content = props.innerHTML;
+    if (this.state.editing) {
+      content = <input ref="input" style={inputStyle} onBlur={this.commitText} onChange={this.sendTextUpdate} value={content} />;
+    }
+    return <p style={style} onClick={this.editText}>{content}</p>;
+  },
+
+  componentDidUpdate: function(prevProps, prevState) {
+    if(this.refs.input) {
+      this.refs.input.getDOMNode().focus();
+    }
+  },
+
+  sendTextUpdate: function(evt) {
+    var value = evt.target.value;
+    this.props.updateText(value);
+  },
+
+  editText: function() {
+    this.setState({
+      editing: true
+    });
+  },
+
+  commitText: function() {
+    this.setState({
+      editing: false
+    });
   }
 });
 

--- a/www_src/pages/element/text-editor.jsx
+++ b/www_src/pages/element/text-editor.jsx
@@ -8,6 +8,35 @@ var Range = require('../../components/range/range.jsx');
 var ColorGroup = require('../../components/color-group/color-group.jsx');
 var {CheckboxSet, Radio} = require('../../components/option-panel/option-panel.jsx');
 
+
+var textStyleOptions = [
+  {
+    id: 'fontWeight',
+    icon: '../../img/B.svg',
+    uncheckedLabel: 'normal',
+    checkedLabel: 'bold'
+  },
+  {
+    id: 'fontStyle',
+    icon: '../../img/I.svg',
+    uncheckedLabel: 'normal',
+    checkedLabel: 'italic'
+  },
+  {
+    id: 'textDecoration',
+    icon: '../../img/U.svg',
+    uncheckedLabel: 'none',
+    checkedLabel: 'underline'
+  }
+];
+
+var textAlignOptions = ['left', 'center', 'right'].map(e => {
+  return {
+    value: e,
+    icon: '../../img/align-'+e+'.svg'
+  };
+});
+
 var TextEditor = React.createClass({
   mixins: [React.addons.LinkedStateMixin],
   getInitialState: function () {
@@ -17,51 +46,16 @@ var TextEditor = React.createClass({
   componentDidUpdate: function () {
     this.props.save(this.state);
   },
-  editText: function () {
-    var text = window.prompt('Edit the text');
+  updateText: function (text) {
     this.setState({
       innerHTML: text
     });
   },
   render: function () {
-    var textStyleOptions = [
-      {
-        id: 'fontWeight',
-        icon: '../../img/B.svg',
-        uncheckedLabel: 'normal',
-        checkedLabel: 'bold'
-      },
-      {
-        id: 'fontStyle',
-        icon: '../../img/I.svg',
-        uncheckedLabel: 'normal',
-        checkedLabel: 'italic'
-      },
-      {
-        id: 'textDecoration',
-        icon: '../../img/U.svg',
-        uncheckedLabel: 'none',
-        checkedLabel: 'underline'
-      }
-    ];
-    var textAlignOptions = [
-      {
-        value: 'left',
-        icon: '../../img/align-left.svg',
-      },
-      {
-        value: 'center',
-        icon: '../../img/align-center.svg',
-      },
-      {
-        value: 'right',
-        icon: '../../img/align-right.svg',
-      }
-    ];
     return (
       <div id="editor">
-        <div className="editor-preview" onClick={this.editText}>
-          <TextBlock {...this.state} />
+        <div className="editor-preview">
+          <TextBlock {...this.state} updateText={this.updateText} />
         </div>
         <div className="editor-options">
           <div className="form-group">


### PR DESCRIPTION
Due to how Android works with its views, this can lead to a content flash when the page is restored after editing and the `<Text>` element gets updated, but only after it's been restored with the original text.

This also needs a bit of a CSS tweek on the page itself, because neither the page preview on "project" nor the element preview in the element editor have any text wrapping, whereas the page text element does, for some reason.

Testing:

- go to a project
- go to a page in that project
- add a text element to the page if there isn't one already
- select the text element and tap the edit button
- in the editor view, tap the text to now get "native android" text input

Missing due to updated ticket: "edit text" button, and the "minimum text length 1" restriction