### PR TITLE
Google Analytics Implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:support-v13:22.1.1'
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.google.android.gms:play-services-analytics:7.3.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,5 +27,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v13:21.0.3'
+    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.google.android.gms:play-services-analytics:7.3.0'
 }

--- a/app/src/main/java/mozilla/org/webmaker/MainActivity.java
+++ b/app/src/main/java/mozilla/org/webmaker/MainActivity.java
@@ -3,16 +3,11 @@ package mozilla.org.webmaker;
 import android.app.ActionBar;
 import android.app.Activity;
 import android.app.FragmentTransaction;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
-import android.view.Menu;
 import android.view.MenuItem;
 
-import android.view.Window;
-import android.view.WindowManager;
 import mozilla.org.webmaker.adapter.SectionsPagerAdapter;
 
 

--- a/app/src/main/java/mozilla/org/webmaker/WebmakerActivity.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerActivity.java
@@ -3,14 +3,13 @@ package mozilla.org.webmaker;
 import android.app.Activity;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.Menu;
 import android.view.MenuItem;
-import android.webkit.JavascriptInterface;
 import android.widget.RelativeLayout;
 
-import mozilla.org.webmaker.view.WebmakerWebView;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import mozilla.org.webmaker.view.WebmakerWebView;
 
 public class WebmakerActivity extends Activity {
 

--- a/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
@@ -17,9 +17,12 @@ public class WebmakerApplication extends Application {
 
     // Singleton
     private WebmakerApplication singleton;
-    public WebmakerApplication getInstance(){
-        return singleton;
-    }
+    private GoogleAnalytics analytics;
+    private Tracker tracker;
+
+    public WebmakerApplication getInstance(){ return singleton; }
+    public GoogleAnalytics getAnalytics() { return analytics; }
+    public Tracker getTracker() { return tracker; }
 
     @Override
     public void onCreate() {
@@ -29,15 +32,14 @@ public class WebmakerApplication extends Application {
         Log.v("[Webmaker]", "Application created.");
 
         // Dry run allows you to debug Google Analytics locally without sending data to any servers.
-        GoogleAnalytics analytics = GoogleAnalytics.getInstance(this);
+        analytics = GoogleAnalytics.getInstance(this);
         analytics.setDryRun(false);
 
-        Tracker tracker = analytics.newTracker(R.xml.app_tracker);
+        tracker = analytics.newTracker(R.xml.app_tracker);
         tracker.setAppId(res.getString(R.string.ga_appId));
         tracker.setAppName(res.getString(R.string.ga_appName));
         tracker.enableAutoActivityTracking(true);
         tracker.enableExceptionReporting(true);
-
 
         // Router
         Router.sharedRouter().setContext(getApplicationContext());

--- a/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
@@ -8,8 +8,8 @@ import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
 
 import mozilla.org.webmaker.activity.Element;
-import mozilla.org.webmaker.activity.Project;
 import mozilla.org.webmaker.activity.Page;
+import mozilla.org.webmaker.activity.Project;
 import mozilla.org.webmaker.activity.Tinker;
 import mozilla.org.webmaker.router.Router;
 

--- a/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
@@ -1,7 +1,11 @@
 package mozilla.org.webmaker;
 
 import android.app.Application;
+import android.content.res.Resources;
 import android.util.Log;
+
+import com.google.android.gms.analytics.GoogleAnalytics;
+import com.google.android.gms.analytics.Tracker;
 
 import mozilla.org.webmaker.activity.Element;
 import mozilla.org.webmaker.activity.Project;
@@ -21,10 +25,19 @@ public class WebmakerApplication extends Application {
     public void onCreate() {
         super.onCreate();
         singleton = this;
-
+        Resources res = getResources();
         Log.v("[Webmaker]", "Application created.");
 
-        // @todo Google Analytics
+        // Dry run allows you to debug Google Analytics locally without sending data to any servers.
+        GoogleAnalytics analytics = GoogleAnalytics.getInstance(this);
+        analytics.setDryRun(false);
+
+        Tracker tracker = analytics.newTracker(R.xml.app_tracker);
+        tracker.setAppId(res.getString(R.string.ga_appId));
+        tracker.setAppName(res.getString(R.string.ga_appName));
+        tracker.enableAutoActivityTracking(true);
+        tracker.enableExceptionReporting(true);
+
 
         // Router
         Router.sharedRouter().setContext(getApplicationContext());

--- a/app/src/main/java/mozilla/org/webmaker/activity/Project.java
+++ b/app/src/main/java/mozilla/org/webmaker/activity/Project.java
@@ -1,13 +1,10 @@
 package mozilla.org.webmaker.activity;
 
-import android.os.Bundle;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.RelativeLayout;
+
 import mozilla.org.webmaker.R;
 import mozilla.org.webmaker.WebmakerActivity;
-import mozilla.org.webmaker.view.WebmakerWebView;
 
 public class Project extends WebmakerActivity {
     public Project() {

--- a/app/src/main/java/mozilla/org/webmaker/activity/Tinker.java
+++ b/app/src/main/java/mozilla/org/webmaker/activity/Tinker.java
@@ -2,16 +2,13 @@ package mozilla.org.webmaker.activity;
 
 import android.app.ActionBar;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
-import android.view.Menu;
 import android.view.Window;
 import android.view.WindowManager;
-import android.widget.RelativeLayout;
+
 import mozilla.org.webmaker.R;
 import mozilla.org.webmaker.WebmakerActivity;
-import mozilla.org.webmaker.view.WebmakerWebView;
 
 public class Tinker extends WebmakerActivity {
     public Tinker() {

--- a/app/src/main/java/mozilla/org/webmaker/fragment/WebviewFragment.java
+++ b/app/src/main/java/mozilla/org/webmaker/fragment/WebviewFragment.java
@@ -3,7 +3,6 @@ package mozilla.org.webmaker.fragment;
 import android.annotation.SuppressLint;
 import android.app.Fragment;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/mozilla/org/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/mozilla/org/webmaker/javascript/WebAppInterface.java
@@ -1,13 +1,13 @@
 package mozilla.org.webmaker.javascript;
 
-import mozilla.org.webmaker.router.Router;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
-import android.content.SharedPreferences;
+
+import org.json.JSONObject;
 
 import mozilla.org.webmaker.router.Router;
-import org.json.JSONObject;
 
 public class WebAppInterface {
 

--- a/app/src/main/java/mozilla/org/webmaker/view/WebmakerWebView.java
+++ b/app/src/main/java/mozilla/org/webmaker/view/WebmakerWebView.java
@@ -7,12 +7,13 @@ import android.view.ViewGroup;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
-import android.webkit.WebView;
-
 import android.webkit.JsPromptResult;
 import android.webkit.WebChromeClient;
-import mozilla.org.webmaker.javascript.WebAppInterface;
+import android.webkit.WebView;
+
 import org.json.JSONObject;
+
+import mozilla.org.webmaker.javascript.WebAppInterface;
 
 public class WebmakerWebView extends WebView {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Webmaker</string>
-
     <string name="title_section1">Discover</string>
     <string name="title_section2">Make</string>
     <string name="title_activity_project">Project</string>
@@ -11,4 +10,8 @@
     <string name="action_play">Play</string>
     <string name="action_settings">Project Settings</string>
     <string name="action_share">Share Project</string>
+
+    <!-- Google Analytics App Name & Id -->
+    <string name="ga_appName">Mobile App</string>
+    <string name="ga_appId">97402987</string>
 </resources>

--- a/app/src/main/res/xml/app_tracker.xml
+++ b/app/src/main/res/xml/app_tracker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyDashes">
+    <!-- The apps Analytics Tracking Id -->
+    <string name="ga_trackingId">UA-49796218-8</string>
+
+    <!-- If set you can replace a package address with a easily readable display name instead. -->
+    <screenName name="mozilla.org.webmaker.activity.Project">Project Activity</screenName>
+    <screenName name="mozilla.org.webmaker.activity.Element">Element Activity</screenName>
+    <screenName name="mozilla.org.webmaker.activity.Page">Page Activity</screenName>
+    <screenName name="mozilla.org.webmaker.activity.Tinker">Tinker Activity</screenName>
+    <screenName name="mozilla.org.webmaker.MainActivity">Main Activity</screenName>
+</resources>


### PR DESCRIPTION
Has been thoroughly tested by myself locally, could use some more testing online however. The app name and id are specified in the strings.xml file, because they need to be manually set, otherwise it defaults to the app_name resource instead.

Google Analytics creates a new tracker from the app_tracker.xml file located in the ```res/xml``` folder. This folder contains the tracking id and screen names for each of the activities provided. Screen names have been set for already existing activities, for easier reading. 

This will need to be done for any future activities that are implemented, to stick to the convention. All Google Analytics implementation related stuff is stored in the ```WebmakerApplication.java``` class. For ease of manipulation later on, methods have been provided for both instances, the tracker and GA.

Dry run has been set to false, although its highly recommended that it is set to true while debugging. This will fire the events locally and not send them directly to the server. Good for debugging purposes and seeing how the data is sent before its actually sent to the server.

Closes issue: #1472 @thisandagain 
