### PR TITLE
Add notifications for less and webpack, colors for npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/mozilla/webmaker-android",
   "devDependencies": {
-    "autoless": "^0.1.7",
     "babel": "^5.3.3",
+    "autoless": "git://github.com/k88hudson/autoless.git#notify",
     "babel-core": "^4.7.16",
     "babel-loader": "^4.3.0",
     "colors": "~1.1.0",
@@ -47,14 +47,15 @@
     "mofo-style": "latest",
     "ncp": "^2.0.0",
     "npm": "^2.7.4",
-    "npm-run-all": "^1.2.2",
+    "npm-run-all": "git://github.com/k88hudson/npm-run-all.git#colors",
     "parallelshell": "^1.1.1",
     "proxyquire": "^1.4.0",
     "rimraf": "^2.3.2",
     "should": "^5.2.0",
     "tmp": "0.0.25",
     "watch": "^0.14.0",
-    "webpack": "^1.7.3"
+    "webpack": "^1.7.3",
+    "webpack-notifier": "git://github.com/k88hudson/webpack-notifier.git#more-options"
   },
   "dependencies": {
     "classnames": "1.2.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var getPages = require('./npm_tasks/get-pages');
 var path = require('path');
+var WebpackNotifierPlugin = require('webpack-notifier');
 
 // Prep all entry points
 var entry = {};
@@ -32,5 +33,10 @@ module.exports = {
         include: [path.resolve(__dirname, 'www_src'),  path.resolve(__dirname, 'node_modules')]
       }
     ]
-  }
+  },
+  plugins: [
+    new WebpackNotifierPlugin({
+      error: {sound: true}
+    }),
+  ]
 };


### PR DESCRIPTION
I did a few patches on some of our dev deps that are waiting to land, i thought it would be cool to try them out here:

* autoless: adds notification support and sounds on errors
* webpack-notifier: adds support for per-event custom configuration (error, warning, build, rebuild)
* npm-run-all: preserves colors in `stdout` 