### PR TITLE
Disable GA tracking on debug builds

### DIFF
--- a/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerApplication.java
@@ -27,7 +27,7 @@ public class WebmakerApplication extends Application {
 
         // Dry run allows you to debug Google Analytics locally without sending data to any servers.
         analytics = GoogleAnalytics.getInstance(this);
-        analytics.setDryRun(false);
+        analytics.setDryRun(BuildConfig.DEBUG);
 
         tracker = analytics.newTracker(R.xml.app_tracker);
         tracker.setAppId(res.getString(R.string.ga_appId));


### PR DESCRIPTION
Pretty straightforward. This sets the GA dry-run flag to `TRUE` unless it is a release build. This helps us keep the amount of developer noise in Google Analytics to a minimum.

/cc @adamlofting 