### PR TITLE
Change the element list for Page containers to a keyed object

### DIFF
--- a/www_src/components/element-group/element-group.jsx
+++ b/www_src/components/element-group/element-group.jsx
@@ -5,8 +5,8 @@ var assign = require('react/lib/Object.assign');
 var ElementGroup = React.createClass({
   getDefaultProps: function () {
     return {
-      elements: [],
-      currentElement: -1,
+      elements: {},
+      currentElementId: -1,
       interactive: false
     };
   },
@@ -14,33 +14,29 @@ var ElementGroup = React.createClass({
     return (
       <div className="element-group">
         <div className="deselector" onClick={this.props.onDeselect} />
-        {this.props.elements.map((elProps, i) => {
+        {Object.keys(this.props.elements).map(elementId => {
 
           if (!elProps || !elProps.type) {
             return false;
           }
 
           elProps = assign({}, elProps, {
-            isCurrent: this.props.currentElement === i,
+            isCurrent: this.props.currentElement === elementId,
             interactive: this.props.interactive
           });
 
           // Add callbacks for interactive mode
           if (this.props.onTouchEnd) {
-            elProps.onTouchEnd = this.props.onTouchEnd(elProps.id);
+            elProps.onTouchEnd = this.props.onTouchEnd(elementId);
           }
 
           if (this.props.onUpdate) {
-            elProps.onUpdate = this.props.onUpdate(elProps.id);
-          }
-
-          if (this.props.onUpdate) {
-            elProps.onUpdate = this.props.onUpdate(elProps.id);
+            elProps.onUpdate = this.props.onUpdate(elementId);
           }
 
           return (
             <div className={'el-wrapper' + (elProps.isCurrent ? ' current' : '')}>
-              <El key={'positionable' + i} {...elProps} />
+              <El key={'positionable' + elementId} {...elProps} />
             </div>
           );
         })}


### PR DESCRIPTION
Fixes #1982 by changing the list of elements from a blind array to a an
object that is keyed on element.ids instead.This lets us track the
currentElement by their element.id, too, rather than relying on any particular
array ordering (which may be invalidated by database storage and retrieval)

**Note** that PR is blocked on #2009 and should not be merged until that's fixed.