### PR TITLE
Change the element list for Page containers to a keyed object

### DIFF
--- a/www_src/components/element-group/element-group.jsx
+++ b/www_src/components/element-group/element-group.jsx
@@ -5,42 +5,41 @@ var assign = require('react/lib/Object.assign');
 var ElementGroup = React.createClass({
   getDefaultProps: function () {
     return {
-      elements: [],
-      currentElement: -1,
+      elements: {},
+      currentElementId: -1,
       interactive: false
     };
   },
   render: function () {
+    var elements = this.props.elements;
     return (
       <div className="element-group">
         <div className="deselector" onClick={this.props.onDeselect} />
-        {this.props.elements.map((elProps, i) => {
+        {Object.keys(elements).map(elementId => {
+
+          var elProps = elements[elementId]
 
           if (!elProps || !elProps.type) {
             return false;
           }
 
           elProps = assign({}, elProps, {
-            isCurrent: this.props.currentElement === i,
+            isCurrent: this.props.currentElementId === elementId,
             interactive: this.props.interactive
           });
 
           // Add callbacks for interactive mode
           if (this.props.onTouchEnd) {
-            elProps.onTouchEnd = this.props.onTouchEnd(elProps.id);
+            elProps.onTouchEnd = this.props.onTouchEnd(elementId);
           }
 
           if (this.props.onUpdate) {
-            elProps.onUpdate = this.props.onUpdate(elProps.id);
-          }
-
-          if (this.props.onUpdate) {
-            elProps.onUpdate = this.props.onUpdate(elProps.id);
+            elProps.onUpdate = this.props.onUpdate(elementId);
           }
 
           return (
             <div className={'el-wrapper' + (elProps.isCurrent ? ' current' : '')}>
-              <El key={'positionable' + i} {...elProps} />
+              <El key={'positionable' + elementId} {...elProps} />
             </div>
           );
         })}

--- a/www_src/components/element-group/element-group.jsx
+++ b/www_src/components/element-group/element-group.jsx
@@ -17,7 +17,7 @@ var ElementGroup = React.createClass({
         <div className="deselector" onClick={this.props.onDeselect} />
         {Object.keys(elements).map(elementId => {
 
-          var elProps = elements[elementId]
+          var elProps = elements[elementId];
 
           if (!elProps || !elProps.type) {
             return false;

--- a/www_src/pages/page/page.jsx
+++ b/www_src/pages/page/page.jsx
@@ -143,7 +143,7 @@ var Page = React.createClass({
         }
         if (data && data.element) {
           var id = data.element.id;
-          json.id = id
+          json.id = id;
           state.elements = this.state.elements;
           state.elements[id] = this.flatten(json);
           state.currentElementId = id;


### PR DESCRIPTION
Fixes #1982 by changing the list of elements from a blind array to a an
object that is keyed on element.ids instead.This lets us track the
currentElement by their element.id, too, rather than relying on any particular
array ordering (which may be invalidated by database storage and retrieval)