### PR TITLE
fixes trash icon location and existence if page count < 2

### DIFF
--- a/www_src/pages/project/project.jsx
+++ b/www_src/pages/project/project.jsx
@@ -467,6 +467,10 @@ var Project = React.createClass({
       }
     }
 
+    var removePageButton = this.state.pages.length > 1 ? (
+      <SecondaryButton side="left" off={isPlayOnly || !this.state.selectedEl} onClick={this.removePage} icon="../../img/trash.svg" />
+    ) : false;
+
     return (
       <div id="map">
 
@@ -488,7 +492,7 @@ var Project = React.createClass({
         </div>
 
         <Menu>
-          <SecondaryButton side="right" off={isPlayOnly || !this.state.selectedEl} onClick={this.removePage} icon="../../img/trash.svg" />
+          {removePageButton}
           <PrimaryButton url={pageUrl} off={isPlayOnly || !this.state.selectedEl} href="/pages/page" icon="../../img/pencil.svg" />
           <PrimaryButton onClick={this.zoomFromPage} off={!this.state.isPageZoomed} icon="../../img/zoom-out.svg" />
         </Menu>


### PR DESCRIPTION
- fixes #2029 - trash icon for pages is now on the left, which aligns it with what we have on the dedicated page view
- fixes #2017 - only shows the trash icon if there is more than one page, so that you can't delete pages from projects with only a single page in them (which would leave you with an empty, useless, project view)