### PR TITLE
prevent weird running text

### DIFF
--- a/www_src/components/el/types/text.jsx
+++ b/www_src/components/el/types/text.jsx
@@ -56,8 +56,11 @@ module.exports = React.createClass({
   render: function() {
     var props = this.props;
     var style = {
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
+      overflow: "hidden",
+      textOverflow: "ellipsis"
     };
+
     [
       'fontFamily',
       'color',

--- a/www_src/components/el/types/textedit.js
+++ b/www_src/components/el/types/textedit.js
@@ -72,6 +72,9 @@ module.exports = {
     }
 
     var inputStyle = this.formInputStyle(style);
+    assign(inputStyle, {
+      maxWidth: "100%",
+    });
 
     var sizerstyle = assign({}, inputStyle);
     assign(sizerstyle, {
@@ -83,7 +86,7 @@ module.exports = {
       width: "auto",
       height: "auto",
       position: "fixed",
-      padding: "0 2px",
+      padding: "0 2px"
     });
 
     if(this.refs.sizer) {


### PR DESCRIPTION
This restricts the `<input>` width to 100%, and sets the "in editor" span width to 100% with an ellipsis to hint at more content. When editing, the user can swipe to move to the content like in any other app, and in the page view, there is no cutoff so all the content is visible.