### PR TITLE
save elements in the editing view when the back button is pressed

### DIFF
--- a/www_src/pages/element/element.jsx
+++ b/www_src/pages/element/element.jsx
@@ -35,7 +35,7 @@ render(React.createClass({
 
     var saveBeforeSwitch = function() {
       var goBack = function() {
-        window.Android.goBack()
+        window.Android.goBack();
       };
       if (!this.edits) {
         return goBack();


### PR DESCRIPTION
fixes #2040 by initiating element save when the back button is pressed, rather than when componentDidUpdate triggers (which does not trigger on first time edit).

Test STR:
* create new project
* edit the empty page
* add a text element to the page
* edit the text element
* in the editor, change the text color to something
* hit the back button

In the current code, this will not update the element on the page, the edit appears "lost". With this PR, the element will update properly by saving changes (if there are any changes) to the element any time the back button is pressed, rather than hooking into React lifecycle functions.
