### PR TITLE
Initial zindex work

### DIFF
--- a/www_src/components/element-group/element-group.jsx
+++ b/www_src/components/element-group/element-group.jsx
@@ -10,6 +10,12 @@ var ElementGroup = React.createClass({
       interactive: false
     };
   },
+  /**
+   * Generate the JSX for the element
+   * @param {id} elementId the element's id in the this.props-passed `elements` dictionary
+   * @param {object} elProps The element property sheet from which to build the JSX representation
+   * @return {JSX} an element's JSX representation
+   */
   formElement: function(elementId, elProps) {
     return (
       <div className={'el-wrapper' + (elProps.isCurrent ? ' current' : '')}>
@@ -17,6 +23,12 @@ var ElementGroup = React.createClass({
       </div>
     );
   },
+  /**
+   * Process an element's property sheet, transforming it into
+   * a JSX object for use by React,
+   * @param {id} elementId the element's id in the this.props-passed `elements` dictionary
+   * @return {JSX} an element's JSX representation
+   */
   processProperties: function(elementId) {
     var elProps = this.props.elements[elementId];
 
@@ -40,6 +52,10 @@ var ElementGroup = React.createClass({
 
     return this.formElement(elementId, elProps);
   },
+  /**
+   * Convert all passed element property sheets into JSX elemenets
+   * @return {JSX[]} And array of JSX representations of each element in this.props.elemeents
+   */
   formElements: function () {
     return Object.keys(this.props.elements).map(this.processProperties);
   },

--- a/www_src/components/element-group/element-group.jsx
+++ b/www_src/components/element-group/element-group.jsx
@@ -10,39 +10,44 @@ var ElementGroup = React.createClass({
       interactive: false
     };
   },
+  formElement: function(elementId, elProps) {
+    return (
+      <div className={'el-wrapper' + (elProps.isCurrent ? ' current' : '')}>
+        <El key={'positionable' + elementId} {...elProps} />
+      </div>
+    );
+  },
+  processProperties: function(elementId) {
+    var elProps = this.props.elements[elementId];
+
+    if (!elProps || !elProps.type) {
+      return false;
+    }
+
+    elProps = assign({}, elProps, {
+      isCurrent: this.props.currentElementId === elementId,
+      interactive: this.props.interactive
+    });
+
+    // Add callbacks for interactive mode
+    if (this.props.onTouchEnd) {
+      elProps.onTouchEnd = this.props.onTouchEnd(elementId);
+    }
+
+    if (this.props.onUpdate) {
+      elProps.onUpdate = this.props.onUpdate(elementId);
+    }
+
+    return this.formElement(elementId, elProps);
+  },
+  formElements: function () {
+    return Object.keys(this.props.elements).map(this.processProperties);
+  },
   render: function () {
-    var elements = this.props.elements;
     return (
       <div className="element-group">
         <div className="deselector" onClick={this.props.onDeselect} />
-        {Object.keys(elements).map(elementId => {
-
-          var elProps = elements[elementId];
-
-          if (!elProps || !elProps.type) {
-            return false;
-          }
-
-          elProps = assign({}, elProps, {
-            isCurrent: this.props.currentElementId === elementId,
-            interactive: this.props.interactive
-          });
-
-          // Add callbacks for interactive mode
-          if (this.props.onTouchEnd) {
-            elProps.onTouchEnd = this.props.onTouchEnd(elementId);
-          }
-
-          if (this.props.onUpdate) {
-            elProps.onUpdate = this.props.onUpdate(elementId);
-          }
-
-          return (
-            <div className={'el-wrapper' + (elProps.isCurrent ? ' current' : '')}>
-              <El key={'positionable' + elementId} {...elProps} />
-            </div>
-          );
-        })}
+        { this.formElements() }
       </div>
     );
   }

--- a/www_src/pages/page/page.jsx
+++ b/www_src/pages/page/page.jsx
@@ -149,6 +149,11 @@ var Page = React.createClass({
     });
   },
 
+  /**
+   * Find the highest in-use zindex on the page, so that we can assign
+   * elements added to the page a sensible zindex value.
+   * @return {int} the highest in-use zindex on the page.
+   */
   getHighestIndex: function() {
     return Object.keys(this.state.elements)
                  .map(e => this.state.elements[e].zIndex)

--- a/www_src/pages/page/page.jsx
+++ b/www_src/pages/page/page.jsx
@@ -138,7 +138,9 @@ var Page = React.createClass({
   },
 
   toggleAddMenu: function () {
-    this.setState({showAddMenu: !this.state.showAddMenu});
+    this.setState({
+      showAddMenu: !this.state.showAddMenu
+    });
   },
 
   deselectAll: function () {
@@ -147,9 +149,18 @@ var Page = React.createClass({
     });
   },
 
+  getHighestIndex: function() {
+    return Object.keys(this.state.elements)
+                 .map(e => this.state.elements[e].zIndex)
+                 .reduce((a,b) => a > b ? a : b, 1);
+  },
+
   addElement: function(type) {
+    var highestIndex = this.getHighestIndex();
+
     return () => {
       var json = types[type].spec.generate();
+      json.styles.zIndex = highestIndex + 1;
 
       api({method: 'post', uri: this.uri() + '/elements', json}, (err, data) => {
         var state = {showAddMenu: false};


### PR DESCRIPTION
Addresses part of https://github.com/mozilla/webmaker-android/issues/2019

- refactors element-group.jsx for faster development by splitting up the large render() call into a set of smaller, easier to maintain functions
- gives page.jsx a knowlege of what the highest currently used z-index is when creating new elements, so that it can assign them a z-index that is 1 higher, ensuring new content is always on top of old content.

This patch does **not** add controls for raising/lowering element z-indices. This will be done as a follow up