### PR TITLE
zindex followup

### DIFF
--- a/www_src/components/el/el.jsx
+++ b/www_src/components/el/el.jsx
@@ -1,3 +1,9 @@
+/**
+ * FIXME: TODO: This file need heavy refactoring, as it's mixing props and state to
+ *              a very entangle data thing, even tapping into getInitialState during
+ *              render, which we should never be doing.
+ */
+
 var React = require('react');
 var classes = require('classnames');
 var Spec = require('../../lib/spec');
@@ -74,9 +80,15 @@ var El = React.createClass({
     }
   },
 
-  // Button position is based on the rendered DOM, so we're setting it directly post-render
+  // FIXME: TODO: This function needs to at the very least be moved to the link element,
+  //              but should really be reengineered out of existence, as it's using old
+  //              HTML+JS to solve a problem in React, which has very different ways of
+  //              doing so.
   positionButton: function () {
+    // Button position is based on the rendered DOM, so we're setting it directly post-render
     var elWrapper = this.getDOMNode();
+
+    // FIXME: TODO: React has references, so using querySelector is an immediate red flag
     var elStyleWrapper = elWrapper.querySelector('.style-wrapper');
     var elButton = elWrapper.querySelector('.meta-button');
 
@@ -87,6 +99,9 @@ var El = React.createClass({
     buttonStyle.angle = 0;
     buttonStyle.scale = 1;
 
+    // FIXME: TODO: this should not be here. This data should be read from state (since we
+    //              set it purely during the component's life time), and then use that to
+    //              render the button with the correct style in render().
     elButton.style.transform = Spec.propsToPosition(buttonStyle).transform;
   },
 
@@ -95,6 +110,9 @@ var El = React.createClass({
   },
 
   render: function() {
+    // FIXME: TODO: this should be this.state - getInitialState() is purely for
+    //              getting the state of a component prior to mounting, we've
+    //              overloaded it to do somehow it was never intended to do.
     var state = this.getInitialState();
 
     var className = classes('el', 'el-' + this.props.type, {
@@ -119,6 +137,7 @@ var El = React.createClass({
       );
     }
 
+    // Note: we're rending the element off of this.props, NOT this.state:
     return (
       <div className="el-wrapper">
         <div className="el-container" key={this.props.key}>
@@ -132,9 +151,9 @@ var El = React.createClass({
     );
   },
 
-  onTouchEnd: function () {
+  onTouchEnd: function (modified) {
     if (this.props.onTouchEnd) {
-      this.props.onTouchEnd();
+      this.props.onTouchEnd(modified);
     }
   },
 
@@ -144,6 +163,11 @@ var El = React.createClass({
     }
   },
 
+  /**
+   * Translate an element on the page but prevent it from being dragged
+   * off entirely, by forcing a "safe zone" into which elements get locked
+   * if they'd otherwise run off the page.
+   */
   handleTranslation: function(x, y) {
     var thresh = 45;
 
@@ -155,9 +179,10 @@ var El = React.createClass({
       y: y
     }, function() {
 
+      // FIXME: TODO: this should be done before, not after, updating the state.
       var changed = false;
-      var updatefunction = this.onUpdate;
 
+      var updatefunction = this.onUpdate;
       updatefunction();
 
       var x = this.state.x;
@@ -189,7 +214,7 @@ var El = React.createClass({
             y: y
           }, updatefunction);
       }
-    }.bind(this));
+    });
   },
 
   handleRotationAndScale: function(angle, scale) {

--- a/www_src/lib/touchhandler.js
+++ b/www_src/lib/touchhandler.js
@@ -7,6 +7,7 @@
 
   function resetTransform() {
     return {
+      modified: false,
       x1: false,
       y1: false,
       x2: false,
@@ -49,6 +50,7 @@
         }
         var x = evt.clientX || evt.touches[0].pageX,
             y = evt.clientY || evt.touches[0].pageY;
+        transform.modified = true;
         positionable.handleTranslation(x - transform.x1 + mark.x, y - transform.y1 + mark.y);
       },
 
@@ -63,7 +65,7 @@
         transform = resetTransform();
         positionable.setState({ touchactive: false });
         if (positionable.onTouchEnd) {
-          positionable.onTouchEnd();
+          positionable.onTouchEnd(transform.modified);
         }
       },
 
@@ -114,6 +116,7 @@
             a = Math.atan2(dy,dx),
             da = a - transform.angle + mark.angle,
             s = d/transform.distance * mark.scale;
+        transform.modified = true;
         positionable.handleRotationAndScale(da, s);
       },
 

--- a/www_src/pages/element/element.jsx
+++ b/www_src/pages/element/element.jsx
@@ -27,6 +27,7 @@ render(React.createClass({
     if (hash) {
       element = testIds[hash];
     }
+    // FIXME: TODO: potential bug: hardcoded user account
     return `/users/1/projects/${params.project}/pages/${params.page}/elements/${element}`;
   },
 

--- a/www_src/pages/page/page.jsx
+++ b/www_src/pages/page/page.jsx
@@ -85,8 +85,8 @@ var Page = React.createClass({
               dims={this.state.dims}
               elements={this.state.elements}
               currentElementId={this.state.currentElementId}
-              onTouchEnd={this.save}
-              onUpdate={this.updateElement}
+              onTouchEnd={this.onTouchEnd}
+              onUpdate={this.onUpdate}
               onDeselect={this.deselectAll} />
           </div>
         </div>
@@ -161,6 +161,50 @@ var Page = React.createClass({
                  .reduce((a,b) => a > b ? a : b, 1);
   },
 
+  /**
+   * Elements need to save themselves on a touchend, but depending
+   * on whether they were manipulated or not should make sure their
+   * z-index is the highest index available for rendering: if an
+   * element was only tapped, not manipulated, it should become the
+   * highest visible element on the page.
+   */
+  onTouchEnd: function(elementId) {
+    var save = this.save(elementId);
+    return (modified) => {
+      if(modified) {
+        return save();
+      }
+
+      // A plain tap without positional modificationss means we need
+      // to raise this element's z-index to "the highest number".
+      var elements = this.state.elements,
+          element = elements[elementId],
+          highestIndex = this.getHighestIndex();
+
+      if (element.zIndex !== highestIndex) {
+        element.zIndex = highestIndex + 1;
+      }
+
+      this.setState({
+        elements: elements
+      }, function() {
+        save();
+      });
+    };
+  },
+
+  onUpdate: function (elementId) {
+    return (newProps) => {
+      var elements = this.state.elements;
+      var element = elements[elementId];
+      elements[elementId] = assign(element, newProps);
+      this.setState({
+        elements: elements,
+        currentElementId: elementId
+      });
+    };
+  },
+
   addElement: function(type) {
     var highestIndex = this.getHighestIndex();
 
@@ -172,36 +216,33 @@ var Page = React.createClass({
       api({method: 'post', uri: this.uri() + '/elements', json}, (err, data) => {
         var state = {showAddMenu: false};
         if (err) {
-          console.log('There was an error creating an element', err);
+          console.error('There was an error creating an element', err);
         }
+        var save = function(){};
         if (data && data.element) {
-          var id = data.element.id;
-          json.id = id;
+          var elementId = data.element.id;
+          json.id = elementId;
           state.elements = this.state.elements;
-          state.elements[id] = this.flatten(json);
-          state.currentElementId = id;
+          state.elements[elementId] = this.flatten(json);
+          state.currentElementId = elementId;
+          save = this.save(elementId);
         }
-        this.setState(state);
+        this.setState(state, function() {
+          save();
+        });
 
-        //Ensure we don't reach a race conditions where the buttons are
-        //re-enabled before the menu is hidden. 200ms matches the css animation
-        //speed.
+        // FIXME: TODO: This timeout should not be here, if the buttons are disabled
+        //              until the element has been added, then the element finishing
+        //              adding itself should lead -in that child element- to a call
+        //              to its "this.props.dosomething", which was passed down by
+        //              the parent, and then in this component that function would
+        //              lead to a this.setState({ disabledButtons: false }).
+        //
+        // https://github.com/mozilla/webmaker-android/issues/2074 has been filed to fix this
 
         setTimeout(function() {
           this.setState({disableButtons: false });
         }.bind(this), 200);
-      });
-    };
-  },
-
-  updateElement: function (elementId) {
-    return (newProps) => {
-      var elements = this.state.elements;
-      var element = elements[elementId];
-      elements[elementId] = assign(element, newProps);
-      this.setState({
-        elements: elements,
-        currentElementId: elementId
       });
     };
   },

--- a/www_src/pages/project/pageblock.jsx
+++ b/www_src/pages/project/pageblock.jsx
@@ -1,0 +1,38 @@
+var React = require('react/addons');
+var classNames = require('classnames');
+var ElementGroup = require('../../components/element-group/element-group.jsx');
+
+/**
+ * This is the component used in the Project view that draws pages as
+ * a "simple page representation" rather than the detailed representation
+ * you get when you navigate to the Page view.
+ */
+var PageBlock = React.createClass({
+
+  render: function() {
+    var classes = classNames('page-container', {
+      selected: this.props.selected,
+      unselected: this.props.unselected,
+      source: this.props.source,
+      target: this.props.target
+    });
+
+    var style = {
+      backgroundColor: this.props.page.styles.backgroundColor,
+      transform: this.props.transform
+    };
+
+    // The "shim" and "indicator" divs don't actually house any content,
+    // suggesting that either they are intended to be empty, or they will
+    // be hooked into later, in which case we have failed to uphold React
+    // practices and reverted to traditional HTML work, which would be bad.
+    return (<div className={classes} style={style} onClick={this.props.onClick}>
+      <div className="shim">
+        <div className="indicator"/>
+      </div>
+      <ElementGroup elements={this.props.page.elements} />
+    </div>);
+  }
+});
+
+module.exports = PageBlock;

--- a/www_src/pages/project/project.jsx
+++ b/www_src/pages/project/project.jsx
@@ -1,7 +1,6 @@
 var React = require('react/addons');
 var update = React.addons.update;
 var assign = require('react/lib/Object.assign');
-var classNames = require('classnames');
 
 var render = require('../../lib/render.jsx');
 var router = require('../../lib/router.jsx');
@@ -9,7 +8,6 @@ var Cartesian = require('../../lib/cartesian');
 var Loading = require('../../components/loading/loading.jsx');
 var {Menu, PrimaryButton, SecondaryButton} = require('../../components/action-menu/action-menu.jsx');
 var types = require('../../components/el/el.jsx').types;
-var ElementGroup = require('../../components/element-group/element-group.jsx');
 
 var api = require('../../lib/api');
 var calculateSwipe = require('../../lib/swipe.js');
@@ -19,26 +17,7 @@ var MIN_ZOOM = 0.18;
 var DEFAULT_ZOOM = 0.5;
 var ZOOM_SENSITIVITY = 300;
 
-var Page = React.createClass({
-  render: function () {
-    var classes = classNames('page-container', {
-      selected: this.props.selected,
-      unselected: this.props.unselected,
-      source: this.props.source,
-      target: this.props.target
-    });
-    var style = {
-      backgroundColor: this.props.page.styles.backgroundColor,
-      transform: this.props.transform
-    };
-    return (<div className={classes} style={style} onClick={this.props.onClick}>
-      <div className="shim">
-        <div className="indicator"/>
-      </div>
-      <ElementGroup elements={this.props.page.elements} />
-    </div>);
-  }
-});
+var PageBlock = require("./pageblock.jsx");
 
 var Project = React.createClass({
   mixins: [router],
@@ -275,6 +254,7 @@ var Project = React.createClass({
   zoomOut: function () {
     this.setState({zoom: this.state.zoom / 2});
   },
+
   zoomIn: function () {
     this.setState({zoom: this.state.zoom * 2});
   },
@@ -330,12 +310,11 @@ var Project = React.createClass({
             y: 0
           }
         }, (err, data) => {
-          console.log(err, data);
           if (err) {
             console.error('Error creating first page', err);
             this.setState({loading: false});
           } else if (!data || !data.page) {
-            console.log('No page id was returned');
+            console.error('No page id was returned');
             this.setState({loading: false});
           } else {
             this.loadPages([{
@@ -369,11 +348,11 @@ var Project = React.createClass({
       }, (err, data) => {
         this.setState({loading: false});
         if (err) {
-          return console.log('Error loading project', err);
+          return console.error('Error loading project', err);
         }
 
         if (!data || !data.page) {
-          return console.log('No page id returned');
+          return console.error('No page id returned');
         }
 
         json.id = data.page.id;
@@ -487,7 +466,7 @@ var Project = React.createClass({
               transform: this.cartesian.getTransform(page.coords),
               onClick: this.onPageClick.bind(this, page)
             };
-            return (<Page {...props} />);
+            return (<PageBlock {...props} />);
           })}
           { generateAddContainers() }
           </div>


### PR DESCRIPTION
Fixes #2019 for the most part.

Tapping on elements, without manipulating them, will assign them highest visibility on the page (unless they are already the highest visibility). This leaves on curious bug, where somehow, something can restore the previous state of the element when you drag it over the page, so that during drag, its previous zindex is used. I've spent several hours trying to figure out why, and have run out of ideas. At this point `el.jsx` is doing a lot of things in a way that does not follow React, so I suspect the only true way to solve this remaining bug is to firest fix up `el.jsx` to follow proper React guidelines again.