### PR TITLE
Adds the Roboto, Bitter, and Pacfico fonts

### DIFF
--- a/www_src/html/index.html
+++ b/www_src/html/index.html
@@ -9,5 +9,6 @@
 <body>
   <div id="app"></div>
   <script src="{{ js_src }}"></script>
+  <link href="http://fonts.googleapis.com/css?family=Bitter|Roboto|Pacifico" rel="stylesheet">
 </body>
 </html>

--- a/www_src/pages/element/font-selector.js
+++ b/www_src/pages/element/font-selector.js
@@ -1,0 +1,22 @@
+var React = require('react/addons');
+
+/**
+ * This is a mixin due to the fact that we rely on this.linkState,
+ * which handles the automatic state binding to whatever component
+ * is using this font selection component for changing font-family
+ */
+module.exports = {
+  /**
+   * Generate the dropdown selector for fonts, with each font option
+   * styled in the appropriate font.
+   * @return {[type]}
+   */
+  generateFontSelector: function() {
+    var fonts = ["Roboto", "Bitter", "Pacifico"];
+    var options = fonts.map(name => {
+      // setting style on an <option> does not work in WebView...
+      return <option key={name} value={name}>{name}</option>;
+    });
+    return <select className="select" valueLink={this.linkState('fontFamily')}>{ options }</select>;
+  }
+};

--- a/www_src/pages/element/link-editor.jsx
+++ b/www_src/pages/element/link-editor.jsx
@@ -8,7 +8,8 @@ var Slider = require('../../components/range/range.jsx');
 var LinkEditor = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
-    require('./witheditable')
+    require('./witheditable'),
+    require('./font-selector')
   ],
   getInitialState: function () {
     return LinkBlock.spec.flatten(this.props.element, {defaults: true});
@@ -53,11 +54,7 @@ var LinkEditor = React.createClass({
           </div>
           <div className="form-group">
             <label>Font</label>
-            <select className="select" valueLink={this.linkState('fontFamily')}>
-              <option value="Roboto">Roboto</option>
-              <option value="Bitter">Bitter</option>
-              <option value="Pacifico">Pacifico</option>
-            </select>
+            { this.generateFontSelector() }
           </div>
           <div className="form-group">
             <label>Background Color</label>

--- a/www_src/pages/element/text-editor.jsx
+++ b/www_src/pages/element/text-editor.jsx
@@ -35,7 +35,8 @@ var textAlignOptions = ['left', 'center', 'right'].map(e => {
 var TextEditor = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
-    require('./witheditable')
+    require('./witheditable'),
+    require('./font-selector')
   ],
   getInitialState: function () {
     return TextBlock.spec.flatten(this.props.element, {defaults: true});
@@ -56,11 +57,7 @@ var TextEditor = React.createClass({
             </div>
             <div className="form-group">
               <label>Font</label>
-              <select className="select" valueLink={this.linkState('fontFamily')}>
-                <option value="Roboto">Roboto</option>
-                <option value="Bitter">Bitter</option>
-                <option value="Pacifico">Pacifico</option>
-              </select>
+              { this.generateFontSelector() }
             </div>
             <div className="form-group">
               <label>Color</label>


### PR DESCRIPTION
Tries to address #1750, but can't.

This PR adds the three fonts we use as webfonts, and refactors the font `<select>` as a mixin for the text and image element to make use of (drying out the code a little).

Unfortunately, WebView doesn't allow CSS styling on `<option>` elements, unlike Firefox or Chrome, it looks like. So we can't get a nice preview of what the font looks like without moving to a "not a `<select>` element anymore" drop down menu.