### PR TITLE
Allow JS interfacing users to send GA events

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,16 @@ if (window.Android) {
 ```js
 window.Android.getMemStorage('state', true);
 ```
+
+#### Google Analytics Event Firing
+
+This function allows you to send event data to Google Analytics by calling the ```trackEvent()``` method. Optionally you can specify a numeric value (int) to pass along in your event, however this isn't required. Please see the below code for example implementation.
+
+You can read more about the parameters and what they do here: https://developers.google.com/analytics/devguides/collection/android/v4/events
+
+```js
+if (window.Android) {
+    window.Android.trackEvent('category', 'action', 'label');
+    window.Android.trackEvent('category', 'action', 'label', 'value'); // optional value
+}
+```

--- a/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
@@ -12,12 +12,12 @@ import org.mozilla.webmaker.router.Router;
 public class WebmakerApplication extends Application {
 
     private WebmakerApplication singleton;
-    private GoogleAnalytics analytics;
-    private Tracker tracker;
+    private static GoogleAnalytics analytics;
+    private static Tracker tracker;
 
     public WebmakerApplication getInstance() { return singleton; }
-    public GoogleAnalytics getAnalytics() { return analytics; }
-    public Tracker getTracker() { return tracker; }
+    public static GoogleAnalytics getAnalytics() { return analytics; }
+    public static Tracker getTracker() { return tracker; }
 
     @Override
     public void onCreate() {

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -3,11 +3,13 @@ package org.mozilla.webmaker.javascript;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.util.Log;
+
+import com.google.android.gms.analytics.HitBuilders;
 
 import org.mozilla.webmaker.BuildConfig;
 import org.json.JSONObject;
+import org.mozilla.webmaker.WebmakerApplication;
 import org.xwalk.core.JavascriptInterface;
 
 import org.mozilla.webmaker.BaseActivity;
@@ -78,23 +80,23 @@ public class WebAppInterface {
      */
 
     @JavascriptInterface
-    public String getMemStorage (String key) {
+    public String getMemStorage(String key) {
         return getMemStorage(key, false);
     }
 
     @JavascriptInterface
-    public String getMemStorage (String key, final boolean global) {
+    public String getMemStorage(String key, final boolean global) {
         if (!global) key = key.concat(mPrefKey);
         return MemStorage.sharedStorage().get(key);
     }
 
     @JavascriptInterface
-    public void setMemStorage (String key, final String value) {
+    public void setMemStorage(String key, final String value) {
         setMemStorage(key, value, false);
     }
 
     @JavascriptInterface
-    public void setMemStorage (String key, final String value, final boolean global) {
+    public void setMemStorage(String key, final String value, final boolean global) {
         if (!global) key = key.concat(mPrefKey);
         MemStorage.sharedStorage().put(key, value);
     }
@@ -178,5 +180,23 @@ public class WebAppInterface {
     @JavascriptInterface
     public String getRouteData() {
         return MemStorage.sharedStorage().get(ROUTE_KEY);
+    }
+
+    /**
+     * ----------------------------------------
+     * Google Analytics
+     * ----------------------------------------
+     */
+
+    @JavascriptInterface
+    public void trackEvent(String category, String action, String label) {
+        WebmakerApplication.getTracker().send(new HitBuilders.EventBuilder()
+                .setCategory(category).setAction(action).setLabel(label).build());
+    }
+
+    @JavascriptInterface
+    public void trackEvent(String category, String action, String label, long value) {
+        WebmakerApplication.getTracker().send(new HitBuilders.EventBuilder()
+                .setCategory(category).setAction(action).setLabel(label).setValue(value).build());
     }
 }


### PR DESCRIPTION
This exposes two methods both called trackEvent(). When called it will send a event to Google Analytics with the provided category, action, label and optionally a integer value. This feature allows for events to be called on the JavaScript side of things and partially solves #2073.

/cc @thisandagain @adamlofting

This is a compressed version of the changes in PR #2079.