### PR TITLE
Deep Links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,12 @@
             <meta-data
                     android:name="android.support.PARENT_ACTIVITY"
                     android:value=".MainActivity" />
+            <intent-filter android:label="@string/title_activity_play">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="webmaker" android:host="play" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/org/mozilla/webmaker/activity/Play.java
+++ b/app/src/main/java/org/mozilla/webmaker/activity/Play.java
@@ -1,5 +1,7 @@
 package org.mozilla.webmaker.activity;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import org.json.JSONException;
 import org.mozilla.webmaker.R;
@@ -14,8 +16,25 @@ public class Play extends WebmakerActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // Set "mode" in route params
         try {
             routeParams.put("mode", "play");
+        } catch (JSONException e) {
+            // do nothing
+        }
+
+        // Get data from deep link (if available)
+        Intent intent = getIntent();
+        Uri data = intent.getData();
+
+        // Set route params if valid deep link
+        if (data == null) return;
+        final String user = data.getQueryParameter("user");
+        final String project = data.getQueryParameter("project");
+        if (user == null || project == null) return;
+        try {
+            routeParams.put("user", user);
+            routeParams.put("project", project);
         } catch (JSONException e) {
             // do nothing
         }

--- a/app/src/main/java/org/mozilla/webmaker/activity/Project.java
+++ b/app/src/main/java/org/mozilla/webmaker/activity/Project.java
@@ -54,7 +54,7 @@ public class Project extends WebmakerActivity {
                 Router.sharedRouter().open("/users/" + userId + "/projects/" + id + "/settings");
                 return true;
             case R.id.action_share:
-                final String url = getString(R.string.share_url).concat(id);
+                final String url = getString(R.string.share_url) + "/users/" + userId + "/projects/" + id;
                 Share.launchShareIntent(url, this);
                 return true;
             default:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,10 +17,9 @@
 
     <string name="share_subject">Webmaker</string>
     <string name="share_body">Check out my project on Webmaker!</string>
-    <string name="share_url">https://beta.webmaker.org/projects/</string>
+    <string name="share_url">https://beta.webmaker.org</string>
 
     <!-- Google Analytics App Name & Id -->
     <string name="ga_appName">Mobile App</string>
     <string name="ga_appId">97402987</string>
-
 </resources>


### PR DESCRIPTION
Enables deep links for "play" mode in the app and updates sharing links to reflect the update service design (not yet landed). To test:

- Open Firefox on-device
- Navigate to `webmaker://play?user=1&project=1`