### PR TITLE
Add support for external links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,7 +101,6 @@
         <activity
             android:name=".activity.Login"
             android:label="@string/title_activity_login"
-            android:noHistory="true"
             android:screenOrientation="portrait" >
         </activity>
     </application>

--- a/app/src/main/java/org/mozilla/webmaker/BaseActivity.java
+++ b/app/src/main/java/org/mozilla/webmaker/BaseActivity.java
@@ -1,9 +1,17 @@
 package org.mozilla.webmaker;
 
 import android.app.Activity;
+import android.content.SharedPreferences;
+
+import org.mozilla.webmaker.javascript.WebAppInterface;
 
 public class BaseActivity extends Activity {
     public void goBack() {
         super.onBackPressed();
+    }
+    public boolean isLoggedIn() {
+        SharedPreferences userSession = getSharedPreferences(WebAppInterface.USER_SESSION_KEY, 0);
+        String session = userSession.getString("session", "");
+        return session != null && session != "";
     }
 }

--- a/app/src/main/java/org/mozilla/webmaker/MainActivity.java
+++ b/app/src/main/java/org/mozilla/webmaker/MainActivity.java
@@ -2,6 +2,7 @@ package org.mozilla.webmaker;
 
 import android.app.ActionBar;
 import android.app.FragmentTransaction;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
@@ -22,10 +23,7 @@ public class MainActivity extends BaseActivity implements ActionBar.TabListener 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
-        SharedPreferences userSession = getSharedPreferences(WebAppInterface.USER_SESSION_KEY, 0);
-        String session = userSession.getString("session", "");
-
-        if (session == "") {
+        if (!isLoggedIn()) {
             Router.sharedRouter().open("/login");
             finish();
         }
@@ -69,6 +67,14 @@ public class MainActivity extends BaseActivity implements ActionBar.TabListener 
         }
 
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onBackPressed() {
+        Intent startMain = new Intent(Intent.ACTION_MAIN);
+        startMain.addCategory(Intent.CATEGORY_HOME);
+        startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(startMain);
     }
 
     /**

--- a/app/src/main/java/org/mozilla/webmaker/activity/Login.java
+++ b/app/src/main/java/org/mozilla/webmaker/activity/Login.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.view.Window;
 import org.mozilla.webmaker.R;
 import org.mozilla.webmaker.WebmakerActivity;
+import org.mozilla.webmaker.router.Router;
 
 public class Login extends WebmakerActivity {
     public Login() {
@@ -12,8 +13,23 @@ public class Login extends WebmakerActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
+        if (isLoggedIn()) {
+            Router.sharedRouter().open("/main");
+            finish();
+        }
+
         // No title bar
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onResume() {
+        if (isLoggedIn()) {
+            Router.sharedRouter().open("/main");
+            finish();
+        }
+        super.onResume();
     }
 }

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.Intent;
+import android.net.Uri;
 import android.util.Log;
 
 import com.google.android.gms.analytics.HitBuilders;
@@ -234,5 +235,16 @@ public class WebAppInterface {
     public void trackEvent(String category, String action, String label, long value) {
         WebmakerApplication.getTracker().send(new HitBuilders.EventBuilder()
                 .setCategory(category).setAction(action).setLabel(label).setValue(value).build());
+    }
+
+    /**
+     * ----------------------------------------
+     * Open External URL
+     * ----------------------------------------
+     */
+    @JavascriptInterface
+    public void openExternalUrl(String url) {
+        Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        mActivity.startActivity(i);
     }
 }

--- a/www_src/components/link/link.jsx
+++ b/www_src/components/link/link.jsx
@@ -14,10 +14,18 @@ var Link = React.createClass({
       onClick: (e) => {
         if (window.Android) {
           e.preventDefault();
-          window.Android.setView(this.props.url);
+          if (this.props.external) {
+            window.Android.openExternalUrl(this.props.external);
+          } else if (this.props.url) {
+            window.Android.setView(this.props.url);
+          }
         }
       }
     });
+    if (this.props.external) {
+      props.target = '_blank';
+      props.href = this.props.href || this.props.external;
+    }
     return React.createElement(this.props.tagName, props);
   }
 });

--- a/www_src/pages/login/sign-in.jsx
+++ b/www_src/pages/login/sign-in.jsx
@@ -1,6 +1,7 @@
 var React = require('react/addons');
 var api = require('../../lib/api');
 var FormInput = require('./form-input.jsx');
+var Link = require('../../components/link/link.jsx');
 
 // <SignIn />
 // Component for the Sign in user form. See Login view for usage.
@@ -46,7 +47,7 @@ var SignIn = React.createClass({
       label: 'Password',
       type: 'password',
       required: true,
-      helpText: <a href="#">Reset Password</a>
+      helpText: <Link external="https://id.webmaker.org/reset-password">Reset Password</Link>
     }
   ],
 

--- a/www_src/pages/login/sign-up.jsx
+++ b/www_src/pages/login/sign-up.jsx
@@ -1,6 +1,7 @@
 var React = require('react/addons');
 var api = require('../../lib/api');
 var FormInput = require('./form-input.jsx');
+var Link = require('../../components/link/link.jsx');
 
 // <SignUp />
 // Component for the Sign Up/Create user form. See Login view for usage.
@@ -150,7 +151,7 @@ var SignUp = React.createClass({
         <div className="error" hidden={!this.state.globalError}>
           {this.state.globalError}
         </div>
-        <p className="by-joining">By joining, I agree to Mozilla Webmaker&rsquo;s <a href="#">Terms</a> and <a href="#">Privacy Policy</a></p>
+        <p className="by-joining">By joining, I agree to Mozilla Webmaker&rsquo;s <Link external="https://webmaker.org/en-US/terms">Terms</Link> and <Link external="https://webmaker.org/en-US/privacy">Privacy Policy</Link></p>
       </div>
       <div className="form-group text-center text-larger already-joined">
         Already joined? <a href="#" onClick={this.changeMode}>Sign in</a>


### PR DESCRIPTION
This will resolve https://github.com/mozilla/webmaker-android/issues/2111, but reintroduces a problem we had before:

The issue is that because the `Login` activity is set to `noHistory="true"` in the manifest, tapping on an external link,which launches the browser, and then pressing the back button sends you to the screen *before* login.