### PR TITLE
Add StyleGuide activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,5 +103,11 @@
             android:label="@string/title_activity_login"
             android:screenOrientation="portrait" >
         </activity>
+
+        <activity
+            android:name=".activity.StyleGuide"
+            android:label="@string/title_activity_style_guide"
+            android:screenOrientation="portrait" >
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
@@ -41,6 +41,8 @@ public class WebmakerApplication extends Application {
 
         Router.sharedRouter().map("/login", Login.class);
 
+        Router.sharedRouter().map("/style-guide", StyleGuide.class);
+
         Router.sharedRouter().map("/users/:user/projects/:project", Project.class);
         Router.sharedRouter().map("/users/:user/projects/:project/settings", ProjectSettings.class);
         Router.sharedRouter().map("/users/:user/projects/:project/play", Play.class);

--- a/app/src/main/java/org/mozilla/webmaker/activity/StyleGuide.java
+++ b/app/src/main/java/org/mozilla/webmaker/activity/StyleGuide.java
@@ -1,0 +1,10 @@
+package org.mozilla.webmaker.activity;
+
+import org.mozilla.webmaker.R;
+import org.mozilla.webmaker.WebmakerActivity;
+
+public class StyleGuide extends WebmakerActivity {
+    public StyleGuide() {
+        super("style-guide", R.id.styleguide_layout, R.layout.style_guide_layout, R.menu.menu_style_guide);
+    }
+}

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -258,4 +258,14 @@ public class WebAppInterface {
         Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         mActivity.startActivity(i);
     }
+
+    /**
+     * ----------------------------------------
+     * Is Debug Build
+     * ----------------------------------------
+     */
+    @JavascriptInterface
+    public boolean isDebugBuild() {
+        return BuildConfig.DEBUG;
+    }
 }

--- a/app/src/main/res/layout/style_guide_layout.xml
+++ b/app/src/main/res/layout/style_guide_layout.xml
@@ -1,0 +1,6 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.mozilla.webmaker.activity.StyleGuide"
+    android:id="@+id/styleguide_layout">
+</RelativeLayout>

--- a/app/src/main/res/menu/menu_style_guide.xml
+++ b/app/src/main/res/menu/menu_style_guide.xml
@@ -1,0 +1,4 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context="org.mozilla.webmaker.activity.StyleGuide">
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="title_activity_element">Options</string>
     <string name="title_activity_tinker">Options</string>
     <string name="title_activity_login">Login</string>
+    <string name="title_activity_style_guide">Style Guide</string>
 
     <string name="action_play">Play</string>
     <string name="action_settings">Settings</string>

--- a/app/src/main/res/xml/app_tracker.xml
+++ b/app/src/main/res/xml/app_tracker.xml
@@ -5,8 +5,13 @@
 
     <!-- If set you can replace a package address with a easily readable display name instead. -->
     <screenName name="org.mozilla.webmaker.activity.Project">Project Activity</screenName>
+    <screenName name="org.mozilla.webmaker.activity.ProjectSettings">Project Settings Activity</screenName>
     <screenName name="org.mozilla.webmaker.activity.Element">Element Activity</screenName>
     <screenName name="org.mozilla.webmaker.activity.Page">Page Activity</screenName>
     <screenName name="org.mozilla.webmaker.activity.Tinker">Tinker Activity</screenName>
+    <screenName name="org.mozilla.webmaker.activity.Play">Play Activity</screenName>
+    <screenName name="org.mozilla.webmaker.activity.Link">Link Activity</screenName>
     <screenName name="org.mozilla.webmaker.MainActivity">Main Activity</screenName>
+    <screenName name="org.mozilla.webmaker.StyleGuide">Style Guide Activity</screenName>
+    <screenName name="org.mozilla.webmaker.activity.Login">Login Activity</screenName>
 </resources>

--- a/www_src/pages/make/make.jsx
+++ b/www_src/pages/make/make.jsx
@@ -5,6 +5,7 @@ var Card = require('../../components/card/card.jsx');
 var Loading = require('../../components/loading/loading.jsx');
 var router = require('../../lib/router');
 var dispatcher = require('../../lib/dispatcher');
+var Link = require('../../components/link/link.jsx');
 
 var Make = React.createClass({
   mixins: [router],
@@ -146,7 +147,6 @@ var Make = React.createClass({
           author={project.author.username} />
       );
     });
-
     return (
       <div id="make">
         <div className="profile-card">
@@ -158,6 +158,9 @@ var Make = React.createClass({
         </button>
         {cards}
         <Loading on={this.state.loading} />
+        <Link url="/style-guide" hidden={window.Android && !window.Android.isDebugBuild()} className="btn btn-create btn-block btn-teal">
+           Open Style Guide
+        </Link>
       </div>
     );
   }


### PR DESCRIPTION
Adds a StyleGuide activity on the Android side and a new interface for JS called ```isDebugBuild()``` which returns whether the build is a debug one or a official release. Depending on the value of this option, the StyleGuide button is either displayed or isn't.

This PR also updates the Google Analytics activity display names, as it was out of date and there were new activities that weren't added. Thanks to @k88hudson for explaining some of the JS stuff as well :)

Closes Issue:  #1867