### PR TITLE
[#2178] Fix project card in StyleGuide

### DIFF
--- a/www_src/pages/style-guide/style-guide.jsx
+++ b/www_src/pages/style-guide/style-guide.jsx
@@ -121,7 +121,7 @@ var StyleGuide = React.createClass({
 
         <h3>Card (JSX)</h3>
         <Card
-          url="/project/123"
+          url="/users/styleguide/projects/example"
           href="/pages/project"
           thumbnail="../../img/toucan.svg"
           title="The Birds of the Amazon"


### PR DESCRIPTION
Fixes issue #2178 which was causing the app to crash when you tapped on the project card in style guide, due to a invalid route that wasn't updated for the new user param and a slight typo that existed with the current param.