### PR TITLE
Fix display of transparency on tinker and image editors

### DIFF
--- a/www_src/components/color-spectrum/color-spectrum.jsx
+++ b/www_src/components/color-spectrum/color-spectrum.jsx
@@ -106,7 +106,7 @@ var ColorSpectrum = React.createClass({
         <RGB color={color} onChange={this.updateColor} />
       </div>
       <div className="form-group" hidden={!this.props.Alpha}>
-        <label>Transparency</label>
+        <label>Opacity</label>
         <Alpha color={color} onChange={this.updateColor} />
       </div>
     </div>);

--- a/www_src/components/range/range.jsx
+++ b/www_src/components/range/range.jsx
@@ -8,7 +8,8 @@ module.exports = React.createClass({
       max: 100,
       min: 0,
       step: 1,
-      unit: ''
+      unit: '',
+      percentage: false
     };
   },
   getInitialState: function () {
@@ -27,10 +28,19 @@ module.exports = React.createClass({
     var linkState = this.props.linkState || this.linkState;
     var valueLink = this.valueLink = linkState(this.props.id);
 
+    var currentValue = parseFloat(valueLink.value);
+    var displayValue;
+
+    if (this.props.percentage) {
+      displayValue = `${Math.round(currentValue/this.props.max * 100)}%`;
+    } else {
+      displayValue = `${currentValue}${this.props.unit}`;
+    }
+
     return (
       <div className="range">
-        <input value={valueLink.value} min={this.props.min} max={this.props.max} step={this.props.step} type="range" onChange={this.onChange} />
-        <div className={'range-summary' + (parseFloat(valueLink.value) === this.props.min ? ' min' : '')}>{valueLink.value}{this.props.unit}</div>
+        <input value={currentValue} min={this.props.min} max={this.props.max} step={this.props.step} type="range" onChange={this.onChange} />
+        <div className={'range-summary' + (currentValue === this.props.min ? ' min' : '')}>{displayValue}</div>
       </div>
     );
   }

--- a/www_src/pages/element/image-editor.jsx
+++ b/www_src/pages/element/image-editor.jsx
@@ -44,7 +44,7 @@ var ImageEditor = React.createClass({
           </div>
           <div className="form-group">
             <label>Opacity</label>
-            <Slider id="opacity" min={0} max={1} step={0.01} linkState={this.linkState} />
+            <Slider id="opacity" min={0} max={1} step={0.01} percentage={true} linkState={this.linkState} />
           </div>
           <div className="form-group">
             <label>Border Color</label>


### PR DESCRIPTION
Represent opacity as a percentage on normal editors, tinker editor renames transparency to opacity.