### PR TITLE
[#2192] Load login/signup views based on router params

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,12 @@
             android:name=".activity.Login"
             android:label="@string/title_activity_login"
             android:screenOrientation="portrait" >
+            <intent-filter android:label="@string/title_activity_login">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="webmaker" android:host="login" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/org/mozilla/webmaker/WebmakerActivity.java
+++ b/app/src/main/java/org/mozilla/webmaker/WebmakerActivity.java
@@ -44,6 +44,7 @@ public class WebmakerActivity extends BaseActivity {
                 routeParams.put("element", intentExtras.get("element"));
                 routeParams.put("propertyName", intentExtras.get("propertyName"));
                 routeParams.put("editor", intentExtras.get("editor"));
+                routeParams.put("mode", intentExtras.get("mode"));
             } catch (JSONException e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
+++ b/app/src/main/java/org/mozilla/webmaker/WebmakerApplication.java
@@ -40,6 +40,7 @@ public class WebmakerApplication extends Application {
         Router.sharedRouter().map("/main/:tab", MainActivity.class);
 
         Router.sharedRouter().map("/login", Login.class);
+        Router.sharedRouter().map("/login/:mode", Login.class);
 
         Router.sharedRouter().map("/style-guide", StyleGuide.class);
 

--- a/app/src/main/java/org/mozilla/webmaker/activity/Login.java
+++ b/app/src/main/java/org/mozilla/webmaker/activity/Login.java
@@ -1,7 +1,11 @@
 package org.mozilla.webmaker.activity;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.Window;
+
+import org.json.JSONException;
 import org.mozilla.webmaker.R;
 import org.mozilla.webmaker.WebmakerActivity;
 import org.mozilla.webmaker.router.Router;
@@ -22,6 +26,18 @@ public class Login extends WebmakerActivity {
         // No title bar
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
         super.onCreate(savedInstanceState);
+
+        // Get data from deep link (if available)
+        Intent intent = getIntent();
+        Uri data = intent.getData();
+
+        if (data == null) return;
+        final String mode = data.getQueryParameter("mode");
+        if (mode == null) return;
+        try {
+            routeParams.put("mode", mode);
+        } catch (JSONException e) {
+        }
     }
 
     @Override

--- a/www_src/pages/login/form-input.jsx
+++ b/www_src/pages/login/form-input.jsx
@@ -16,7 +16,7 @@ var FormInput = React.createClass({
   },
   render: function () {
     return (<div className="form-group">
-      <label for={this.props.name}>{this.props.label}</label>
+      <label htmlFor={this.props.name}>{this.props.label}</label>
       <input name={this.props.name} type={this.props.type} tabIndex={this.props.tabIndex} onKeyDown={this.checkForReturn} valueLink={this.props.valueLink} required={this.props.required} />
       <div className="error" hidden={!this.props.errors}>
         {this.props.errors && this.props.errors.join(' ')}

--- a/www_src/pages/login/login.jsx
+++ b/www_src/pages/login/login.jsx
@@ -8,6 +8,8 @@ var SignUp = require('./sign-up.jsx');
 // <Login />
 // View that renders sign-in and sign-up forms
 var Login = React.createClass({
+  mixins: [require('../../lib/router')],
+
   // Props:
   //   (none)
 
@@ -19,8 +21,12 @@ var Login = React.createClass({
   //     boolean
   //     Turns the UI-blocking loader on/off
   getInitialState: function () {
+    var mode = this.getRouteParams().mode;
+    if (['sign-up', 'sign-in'].indexOf(mode) === -1) {
+      mode = 'sign-up';
+    }
     return {
-      mode: 'sign-up',
+      mode,
       loading: false
     };
   },

--- a/www_src/pages/login/sign-in.jsx
+++ b/www_src/pages/login/sign-in.jsx
@@ -116,6 +116,7 @@ var SignIn = React.createClass({
     return (<form hidden={!this.props.show} className="editor-options" onSubmit={this.onSubmit}>
       {this.fields.map(field => {
         return <FormInput {...field}
+          key={field.name}
           onReturn={this.onDoneEditing}
           errors={errors[field.name]}
           valueLink={this.linkState(field.name)} />;

--- a/www_src/pages/login/sign-up.jsx
+++ b/www_src/pages/login/sign-up.jsx
@@ -148,6 +148,7 @@ var SignUp = React.createClass({
 
       {this.fields.map(field => {
         return <FormInput {...field}
+          key={field.name}
           onReturn={this.onDoneEditing}
           errors={errors[field.name]}
           valueLink={this.linkState(field.name)}/>;

--- a/www_src/pages/make/make.jsx
+++ b/www_src/pages/make/make.jsx
@@ -97,7 +97,7 @@ var Make = React.createClass({
     if (window.Android) {
       window.Android.trackEvent('Login', 'Sign Out', 'Sign Out Success');
       window.Android.clearUserSession();
-      window.Android.setView('/login');
+      window.Android.setView('/login/sign-in');
     }
   },
 


### PR DESCRIPTION
This should allow for deep-linking of the sign in screen.

Needs a patch on login to call `webmaker://login?mode=sign-in` to resolve the ticket