### PR TITLE
Use react-imageloaders prerender property to prevent 0 height thumbnails

### DIFF
--- a/www_src/components/card/card.jsx
+++ b/www_src/components/card/card.jsx
@@ -11,11 +11,16 @@ var Card = React.createClass({
     e.stopPropagation();
     this.props.onActionsClick.call(this, this.props);
   },
+  prerenderImage: function() {
+    return React.createElement('img', {
+      src: Card.DEFAULT_THUMBNAIL
+    });
+  },
   render: function () {
     return (
       <Link url={this.props.url} href={this.props.href} className="card">
         <div className="thumbnail">
-          <ImageLoader src={this.props.thumbnail || Card.DEFAULT_THUMBNAIL}></ImageLoader>
+          <ImageLoader src={this.props.thumbnail || Card.DEFAULT_THUMBNAIL} preloader={this.prerenderImage}></ImageLoader>
         </div>
 
         <div className="meta">


### PR DESCRIPTION
Fixes #2207 

This "works" but lets see if we can find a real solution to the strange loading behaviour before going with this.