### PR TITLE
Remove hard requirement for camera from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <uses-feature android:name="android.hardware.screen.portrait" />
-    <uses-feature android:name="android.hardware.camera" android:required="true" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:name=".WebmakerApplication"

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -149,13 +149,11 @@ public class WebAppInterface {
 
     @JavascriptInterface
     public void getFromCamera() {
-        // Check to ensure camera is available from device
-        if (!cameraIsAvailable()) return;
-
-        // Dispatch intent
-        Element elementActivity = (Element) mContext;
-        if (elementActivity != null) {
-            elementActivity.dispatchCameraIntent();
+        if (cameraIsAvailable()) {
+            Element elementActivity = (Element) mContext;
+            if (elementActivity != null) {
+                elementActivity.dispatchCameraIntent();
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -140,16 +140,11 @@ public class WebAppInterface {
      */
     @JavascriptInterface
     public boolean cameraIsAvailable() {
-        PackageManager pm = mContext.getPackageManager();
-        boolean available;
+        final PackageManager pm = mContext.getPackageManager();
+        final boolean front = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
+        final boolean rear = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            available = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
-        } else {
-            available = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
-        }
-
-        return available;
+        return front || rear;
     }
 
     @JavascriptInterface

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -4,7 +4,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 
 import com.google.android.gms.analytics.HitBuilders;
@@ -137,7 +139,25 @@ public class WebAppInterface {
      * ---------------------------------------
      */
     @JavascriptInterface
+    public boolean cameraIsAvailable() {
+        PackageManager pm = mContext.getPackageManager();
+        boolean available;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            available = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
+        } else {
+            available = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
+        }
+
+        return available;
+    }
+
+    @JavascriptInterface
     public void getFromCamera() {
+        // Check to ensure camera is available from device
+        if (!cameraIsAvailable()) return;
+
+        // Dispatch intent
         Element elementActivity = (Element) mContext;
         if (elementActivity != null) {
             elementActivity.dispatchCameraIntent();

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -150,9 +150,13 @@ public class WebAppInterface {
     @JavascriptInterface
     public void getFromCamera() {
         if (cameraIsAvailable()) {
-            Element elementActivity = (Element) mContext;
-            if (elementActivity != null) {
-                elementActivity.dispatchCameraIntent();
+            try {
+                Element elementActivity = (Element) mContext;
+                if (elementActivity != null) {
+                    elementActivity.dispatchCameraIntent();
+                }
+            } catch (Exception e) {
+                Log.e("CAMERA", "Attempted to dispatch camera intent.");
             }
         }
     }

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -1,12 +1,12 @@
 package org.mozilla.webmaker.javascript;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.util.Log;
 
 import com.google.android.gms.analytics.HitBuilders;
@@ -155,7 +155,7 @@ public class WebAppInterface {
                 if (elementActivity != null) {
                     elementActivity.dispatchCameraIntent();
                 }
-            } catch (Exception e) {
+            } catch (ActivityNotFoundException e) {
                 Log.e("CAMERA", "Attempted to dispatch camera intent.");
             }
         }

--- a/www_src/pages/element/image-editor.jsx
+++ b/www_src/pages/element/image-editor.jsx
@@ -62,7 +62,7 @@ var ImageEditor = React.createClass({
 
         <div className={classNames({overlay: true, active: this.state.showMenu})} onClick={this.toggleMenu}/>
         <div className={classNames({controls: true, active: this.state.showMenu})}>
-          <button onClick={this.onCameraClick}>
+          <button hidden={window.Android && !window.Android.cameraIsAvailable()} onClick={this.onCameraClick}>
             <img className="icon" src="../../img/take-photo.svg" />
             <p>Take Photo</p>
           </button>


### PR DESCRIPTION
Replaces requirement for camera in the manifest with a soft-check at runtime. This resolves issues with a number of devices that are currently "unsupported" in the Google Play store. This happens for a variety of reasons (inexpensive chipsets, only a front-facing camera, etc.). This PR resolves this issue by updating the manifest and adding a check that works across different Android versions to ensure that a camera is available before launching the intent.

Resolves GH-2255
Resolves GH-2248
Resolves GH-2235
Resolves GH-2209