### PR TITLE
Platform Polyfill

### DIFF
--- a/app/src/main/java/org/mozilla/webmaker/view/WebmakerWebView.java
+++ b/app/src/main/java/org/mozilla/webmaker/view/WebmakerWebView.java
@@ -26,7 +26,6 @@ public class WebmakerWebView extends XWalkView {
         this.load("file:///android_asset/www/pages/" + pageName + "/index.html", null);
         this.setResourceClient(new WebClient(this));
         this.setBackgroundColor(getResources().getColor(R.color.light_gray));
-        this.addJavascriptInterface(new WebAppInterface(context, routeParams), "Android");
-
+        this.addJavascriptInterface(new WebAppInterface(context, routeParams), "Platform");
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "classnames": "1.2.1",
     "color": "0.8.0",
     "lodash.defaults": "3.1.1",
+    "lru-cache": "2.6.5",
     "owasp-password-strength-test": "1.2.2",
     "react": "0.13.1",
     "react-hammerjs": "0.2.2",

--- a/www_src/components/basic-element/basic-element.jsx
+++ b/www_src/components/basic-element/basic-element.jsx
@@ -140,8 +140,8 @@ var BasicElement = React.createClass({
 
   onLinkDestClick: function () {
     if (this.props.targetPageId) {
-      if (window.Android) {
-        window.Android.setView(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
+      if (window.Platform) {
+        window.Platform.setView(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
       }
     } else {
       dispatcher.fire('linkDestinationClicked', this.props);

--- a/www_src/components/basic-element/types/textedit.js
+++ b/www_src/components/basic-element/types/textedit.js
@@ -142,7 +142,7 @@ module.exports = {
     // typing with the cursor placed at the end of an input element.
     //
     // See https://github.com/mozilla/webmaker-android/issues/2050 for more details.
-    if(!this._replaced && window.Android) {
+    if(!this._replaced && window.Platform) {
       value = value.replace(this._content, '');
       this._replaced = true;
     }

--- a/www_src/components/color-group/color-group.jsx
+++ b/www_src/components/color-group/color-group.jsx
@@ -42,14 +42,14 @@ var ColorGroup = React.createClass({
       this.props.onChange(this.valueLink.value);
     }
 
-    if (!window.Android) {
+    if (!window.Platform) {
       return;
     }
 
     e.preventDefault();
 
     var launch = () => {
-      window.Android.setView(this.getTinkerUrl());
+      window.Platform.setView(this.getTinkerUrl());
     };
 
     if (this.props.onLaunchTinker) {

--- a/www_src/components/link/link.jsx
+++ b/www_src/components/link/link.jsx
@@ -12,12 +12,12 @@ var Link = React.createClass({
     var props = assign({}, this.props, {
       className,
       onClick: (e) => {
-        if (window.Android) {
+        if (window.Platform) {
           e.preventDefault();
           if (this.props.external) {
-            window.Android.openExternalUrl(this.props.external);
+            window.Platform.openExternalUrl(this.props.external);
           } else if (this.props.url) {
-            window.Android.setView(this.props.url);
+            window.Platform.setView(this.props.url);
           }
         }
       }

--- a/www_src/lib/api.js
+++ b/www_src/lib/api.js
@@ -1,10 +1,12 @@
 var xhr = require('xhr');
 var defaults = require('lodash.defaults');
-var {jsonToFormEncoded, parseJSON} = require('./jsonUtils');
-var router = require('./router');
 var assign = require('react/lib/Object.assign');
-var dispatcher = require('./dispatcher');
+
 var config = require('../config');
+var dispatcher = require('./dispatcher');
+var platform = require('./platform');
+var router = require('./router');
+var {jsonToFormEncoded, parseJSON} = require('./jsonUtils');
 
 function api(options, callback) {
 
@@ -41,13 +43,11 @@ function api(options, callback) {
     options.headers.Authorization = 'token ' + router.getUserSession().token;
   }
 
-  // Set cache key
+  // Caching
   var key = 'cache::' + options.method + '::' + options.uri;
-
-  // Use device cache if window.Android is available & options.useCache is true
-  if (window.Android && options.useCache === true && options.method === 'GET') {
+  if (options.useCache === true && options.method === 'GET') {
     console.log('Fetching from cache "' + key + '"');
-    var hit = window.Android.getMemStorage(key, true);
+    var hit = platform.getMemStorage(key, true);
     if (typeof hit === 'string') {
       return callback(null, JSON.parse(hit));
     }
@@ -68,10 +68,8 @@ function api(options, callback) {
       return callback(err);
     }
 
-    // Set cache if window.Android is available
-    if (window.Android) {
-      window.Android.setMemStorage(key, JSON.stringify(body), true);
-    }
+    // Set cache
+    platform.setMemStorage(key, JSON.stringify(body), true);
 
     // If there is a callback, forward the response body
     if (callback) {

--- a/www_src/lib/platform.js
+++ b/www_src/lib/platform.js
@@ -1,0 +1,171 @@
+/**
+ * Device agnostic platform interface.
+ *
+ * @package core
+ * @author Andrew Sliwinski <a@mozillafoundation.org>
+ */
+
+var lru = require('lru-cache');
+
+/**
+ * Constructor
+ */
+function Platform () {
+  // Check to see if window.Platform exists. If it does, return it.
+  if (window.Platform) {
+    return window.Platform;
+  }
+
+  // Init storage objects
+  this.sharedStorage = window.localStorage;
+  this.memStorage = lru(50);
+  this.sessionKey = 'WEBMAKER_SESSION';
+  this.cacheKey = '::' + window.pathname;
+}
+
+// -----------------------------------------------------------------------------
+// Persistent storage
+// -----------------------------------------------------------------------------
+
+Platform.prototype.getSharedPreferences = function(key, global) {
+  if (!global) {
+    key += this.cacheKey;
+  }
+  return this.sharedStorage.getItem(key);
+};
+
+Platform.prototype.setSharedPreferences = function(key, value, global) {
+  if (!global) {
+    key += this.cacheKey;
+  }
+  return this.sharedStorage.setItem(key, value);
+};
+
+Platform.prototype.resetSharedPreferences = function() {
+  return this.sharedStorage.clear();
+};
+
+// -----------------------------------------------------------------------------
+// Session storage
+// -----------------------------------------------------------------------------
+
+Platform.prototype.getUserSession = function() {
+  return this.getSharedPreferences(this.sessionKey);
+};
+
+Platform.prototype.setUserSession = function(data) {
+  return this.setUserSession(this.sessionKey, data);
+};
+
+Platform.prototype.clearUserSession = function() {
+  return this.setUserSession(this.sessionKey, null);
+};
+
+// -----------------------------------------------------------------------------
+// Memory (LRU) storage
+// -----------------------------------------------------------------------------
+
+Platform.prototype.getMemStorage = function(key, global) {
+  if (!global) {
+    key += this.cacheKey;
+  }
+  return this.memStorage.get(key);
+};
+
+Platform.prototype.setMemStorage = function(key, value, global) {
+  if (!global) {
+    key += this.cacheKey;
+  }
+  return this.memStorage.set(key, value);
+};
+
+// -----------------------------------------------------------------------------
+// Navigation
+// -----------------------------------------------------------------------------
+
+Platform.prototype.setView = function(uri) {
+  window.location.href = uri;
+};
+
+Platform.prototype.openExternalUrl = function(uri) {
+  window.location = uri;
+};
+
+Platform.prototype.goBack = function() {
+  // @todo
+};
+
+Platform.prototype.goToHomeScreen = function() {
+  // @todo
+};
+
+// -----------------------------------------------------------------------------
+// Router
+// -----------------------------------------------------------------------------
+
+Platform.prototype.getRouteParams = function() {
+  // @todo
+};
+
+Platform.prototype.getRouteData = function() {
+  // @todo
+};
+
+Platform.prototype.clearRouteData = function() {
+  // @todo
+};
+
+// -----------------------------------------------------------------------------
+// Images
+// -----------------------------------------------------------------------------
+
+Platform.prototype.cameraIsAvailable = function() {
+  // @todo
+  return false;
+};
+
+Platform.prototype.getFromCamera = function() {
+  // @todo
+};
+
+Platform.prototype.getFromMedia = function() {
+  // @todo
+};
+
+// -----------------------------------------------------------------------------
+// Sharing
+// -----------------------------------------------------------------------------
+
+Platform.prototype.shareProject = function() {
+  // @todo
+};
+
+// -----------------------------------------------------------------------------
+// Google Analytics
+// -----------------------------------------------------------------------------
+
+Platform.prototype.trackEvent = function(category, action, label, value) {
+  if (!window.ga) {
+    return;
+  }
+
+  window.ga('send', {
+    'hitType': 'event',
+    'eventCategory': category,
+    'eventAction': action,
+    'eventLabel': label,
+    'eventValue': value
+  });
+};
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+Platform.prototype.isDebugBuild = function() {
+  // @todo
+  return false;
+};
+
+
+module.exports = new Platform();

--- a/www_src/lib/render.jsx
+++ b/www_src/lib/render.jsx
@@ -1,8 +1,11 @@
 var React = require('react');
+
 var Spindicator = require('../components/spindicator/spindicator.jsx');
 var ModalConfirm = require('../components/modal-confirm/modal-confirm.jsx');
 var ModalSwitch = require('../components/modal-switch/modal-switch.jsx');
 var Snackbar = require('../components/snackbar/snackbar.jsx');
+
+var platform = require('./platform');
 
 var Base = React.createClass({
   onResume: function () {
@@ -14,8 +17,8 @@ var Base = React.createClass({
   onBackPressed: function() {
     if (this.state.onBackPressed) {
       return this.state.onBackPressed();
-    } else if (window.Android) {
-      window.Android.goBack();
+    } else {
+      platform.goBack();
     }
   },
   jsComm: function (event) {

--- a/www_src/lib/router.js
+++ b/www_src/lib/router.js
@@ -2,7 +2,7 @@ var {parseJSON} = require('./jsonUtils');
 
 module.exports = {
 
-  android: window.Android,
+  android: window.Platform,
 
   getRouteParams: function () {
     var params = {};
@@ -49,7 +49,7 @@ module.exports = {
   //
   // Returns user session from android if it exists,
   // or else an empty object.
-  // if window.Android doesn't exist, returns test data
+  // if window.Platform doesn't exist, returns test data
   // e.g.
   // {
   //  user: {id: 1, username: 'foo', ...},

--- a/www_src/pages/element/element.jsx
+++ b/www_src/pages/element/element.jsx
@@ -38,7 +38,7 @@ render(React.createClass({
 
     var saveBeforeSwitch = function() {
       var goBack = function() {
-        window.Android.goBack();
+        window.Platform.goBack();
       };
       if (!this.edits) {
         return goBack();
@@ -153,7 +153,7 @@ render(React.createClass({
 
     return (<div id="editor">
       <Editor {...props} />
-      <button hidden={window.Android} onClick={this.save}>DEBUG:SAVE</button>
+      <button hidden={window.Platform} onClick={this.save}>DEBUG:SAVE</button>
       <Loading on={this.state.loading}/>
     </div>);
   }

--- a/www_src/pages/element/image-editor.jsx
+++ b/www_src/pages/element/image-editor.jsx
@@ -62,7 +62,7 @@ var ImageEditor = React.createClass({
 
         <div className={classNames({overlay: true, active: this.state.showMenu})} onClick={this.toggleMenu}/>
         <div className={classNames({controls: true, active: this.state.showMenu})}>
-          <button hidden={window.Android && !window.Android.cameraIsAvailable()} onClick={this.onCameraClick}>
+          <button hidden={window.Platform && !window.Platform.cameraIsAvailable()} onClick={this.onCameraClick}>
             <img className="icon" src="../../img/take-photo.svg" />
             <p>Take Photo</p>
           </button>
@@ -84,8 +84,8 @@ var ImageEditor = React.createClass({
     this.props.cancelDataRefresh();
 
     this.toggleMenu();
-    if (window.Android) {
-      window.Android.getFromCamera();
+    if (window.Platform) {
+      window.Platform.getFromCamera();
     }
   },
   onMediaClick: function () {
@@ -95,8 +95,8 @@ var ImageEditor = React.createClass({
     this.props.cancelDataRefresh();
 
     this.toggleMenu();
-    if (window.Android) {
-      window.Android.getFromMedia();
+    if (window.Platform) {
+      window.Platform.getFromMedia();
     }
   },
   imageReady: function (uri) {

--- a/www_src/pages/element/link-editor.jsx
+++ b/www_src/pages/element/link-editor.jsx
@@ -53,8 +53,8 @@ var LinkEditor = React.createClass({
         console.error('There was an error updating the element', err);
       }
 
-      if (window.Android) {
-        window.Android.setView(
+      if (window.Platform) {
+        window.Platform.setView(
           `/users/${this.props.params.user}/projects/${this.props.params.project}/link`,
           JSON.stringify(metadata)
         );

--- a/www_src/pages/login/login.jsx
+++ b/www_src/pages/login/login.jsx
@@ -33,7 +33,7 @@ var Login = React.createClass({
   componentWillMount: function () {
     this.props.update({
       onBackPressed: () => {
-        window.Android.goToHomeScreen();
+        window.Platform.goToHomeScreen();
       }
     });
   },

--- a/www_src/pages/login/sign-in.jsx
+++ b/www_src/pages/login/sign-in.jsx
@@ -86,8 +86,8 @@ var SignIn = React.createClass({
     api.authenticate({json}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Android) {
-          window.Android.trackEvent('Login', 'Sign In', 'Sign In Error');
+        if (window.Platform) {
+          window.Platform.trackEvent('Login', 'Sign In', 'Sign In Error');
         }
         this.setState({globalError: true});
         return reportError("Error while trying to log in", err);
@@ -95,10 +95,10 @@ var SignIn = React.createClass({
 
       this.replaceState(this.getInitialState());
 
-      if (window.Android) {
-        window.Android.trackEvent('Login', 'Sign In', 'Sign In Success');
-        window.Android.setUserSession(JSON.stringify(data));
-        window.Android.setView('/main');
+      if (window.Platform) {
+        window.Platform.trackEvent('Login', 'Sign In', 'Sign In Success');
+        window.Platform.setUserSession(JSON.stringify(data));
+        window.Platform.setView('/main');
       }
     });
   },

--- a/www_src/pages/login/sign-up.jsx
+++ b/www_src/pages/login/sign-up.jsx
@@ -103,8 +103,8 @@ var SignUp = React.createClass({
     api.signUp({json: options}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Android) {
-          window.Android.trackEvent('Login', 'Sign Up', 'Sign Up Error');
+        if (window.Platform) {
+          window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
         }
         this.setState({globalError: err.message || 'Something went wrong.' });
         return reportError("Error while trying to sign up", err);
@@ -112,10 +112,10 @@ var SignUp = React.createClass({
 
       this.replaceState(this.getInitialState());
 
-      if (window.Android) {
-        window.Android.trackEvent('Login', 'Sign Up', 'Sign Up Success');
-        window.Android.setUserSession(JSON.stringify(data));
-        window.Android.setView('/main');
+      if (window.Platform) {
+        window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Success');
+        window.Platform.setUserSession(JSON.stringify(data));
+        window.Platform.setView('/main');
       }
     });
   },

--- a/www_src/pages/make/make.jsx
+++ b/www_src/pages/make/make.jsx
@@ -2,6 +2,7 @@ var React = require('react');
 var api = require('../../lib/api');
 var router = require('../../lib/router');
 var dispatcher = require('../../lib/dispatcher');
+var platform = require('../../lib/platform');
 var reportError = require('../../lib/errors');
 
 var render = require('../../lib/render.jsx');
@@ -79,10 +80,9 @@ var Make = React.createClass({
       if (!body || !body.project) {
         return this.onEmpty();
       }
-      if (window.Android) {
-        window.Android.trackEvent('Make', 'Create a Project', 'New Project Started');
-        window.Android.setView('/users/' + user.id + '/projects/' + body.project.id);
-      }
+      
+      platform.trackEvent('Make', 'Create a Project', 'New Project Started');
+      platform.setView('/users/' + user.id + '/projects/' + body.project.id);
 
       body.project.author = body.project.author || user;
 
@@ -94,11 +94,9 @@ var Make = React.createClass({
   },
 
   logout: function () {
-    if (window.Android) {
-      window.Android.trackEvent('Login', 'Sign Out', 'Sign Out Success');
-      window.Android.clearUserSession();
-      window.Android.setView('/login/sign-in');
-    }
+    platform.trackEvent('Login', 'Sign Out', 'Sign Out Success');
+    platform.clearUserSession();
+    platform.setView('/login/sign-in');
   },
 
   cardActionClick: function (e) {
@@ -119,16 +117,12 @@ var Make = React.createClass({
                 return this.onError(err);
               }
 
-              if (window.Android) {
-                window.Android.trackEvent('Make', 'Delete Project', 'Project Deleted');
-              }
+              platform.trackEvent('Make', 'Delete Project', 'Project Deleted');
               console.log('Deleted project: ' + e.projectID);
               this.load();
             });
           } else if (event.label === 'Share') {
-            if (window.Android) {
-              window.Android.shareProject(this.state.user.id, e.projectID);
-            }
+            platform.shareProject(this.state.user.id, e.projectID);
           }
         }
       }
@@ -162,10 +156,10 @@ var Make = React.createClass({
         </button>
         {cards}
         <Loading on={this.state.loading} />
-        <Link url="/style-guide" hidden={window.Android && !window.Android.isDebugBuild()} className="btn btn-create btn-block btn-teal">
+        <Link url="/style-guide" hidden={platform.isDebugBuild()} className="btn btn-create btn-block btn-teal">
            Open Style Guide
         </Link>
-        <button hidden={window.Android && !window.Android.isDebugBuild()} onClick={window.Android.resetSharedPreferences()} className="btn btn-create btn-block btn-teal">
+        <button hidden={platform.isDebugBuild()} onClick={platform.resetSharedPreferences()} className="btn btn-create btn-block btn-teal">
           Reset Shared Preferences
         </button>
       </div>

--- a/www_src/pages/page/page.jsx
+++ b/www_src/pages/page/page.jsx
@@ -88,8 +88,8 @@ var Page = React.createClass({
       userID: this.state.params.user
     };
 
-    if (window.Android) {
-      window.Android.setView('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
+    if (window.Platform) {
+      window.Platform.setView('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
     }
   },
 

--- a/www_src/pages/project-settings/project-settings.jsx
+++ b/www_src/pages/project-settings/project-settings.jsx
@@ -31,7 +31,7 @@ var ProjectSettings = React.createClass({
     // Set up the save method when we press the back button
     this.props.update({
       onBackPressed: () => {
-        this.save(() => window.Android.goBack());
+        this.save(() => window.Platform.goBack());
       }
     });
 
@@ -48,7 +48,7 @@ var ProjectSettings = React.createClass({
       <div id="projectSettings">
         <div>
           <TextInput id="title" ref="title" label="Title" maxlength={25} minlength={4} linkState={this.linkState} />
-          <button hidden={window.Android} onClick={this.save}>DEBUG:Save</button>
+          <button hidden={window.Platform} onClick={this.save}>DEBUG:Save</button>
         </div>
 
         <div className="cc">

--- a/www_src/pages/project/loader.js
+++ b/www_src/pages/project/loader.js
@@ -51,7 +51,7 @@ module.exports = {
 
         // Highlight the source page if you're in link destination mode
         if (this.state.params.mode === 'link') {
-          if (window.Android) {
+          if (window.Platform) {
             this.highlightPage(this.state.routeData.pageID, 'source');
           }
         }

--- a/www_src/pages/project/project.jsx
+++ b/www_src/pages/project/project.jsx
@@ -39,14 +39,14 @@ var Project = React.createClass({
       this.load();
     }
 
-    if (window.Android) {
-      window.Android.setMemStorage('state', JSON.stringify(this.state));
+    if (window.Platform) {
+      window.Platform.setMemStorage('state', JSON.stringify(this.state));
     }
   },
 
   componentDidMount: function () {
-    if (window.Android) {
-      var state = window.Android.getMemStorage('state');
+    if (window.Platform) {
+      var state = window.Platform.getMemStorage('state');
       if (this.state.params.mode === 'edit') {
         state = parseJSON(state);
         if (state.params && state.params.project === this.state.params.project) {

--- a/www_src/pages/project/remix.js
+++ b/www_src/pages/project/remix.js
@@ -28,8 +28,8 @@ module.exports = {
             return console.error('Error remixing project', err);
           }
 
-          if (window.Android) {
-            window.Android.setView(
+          if (window.Platform) {
+            window.Platform.setView(
               `/users/${this.state.user.id}/projects/${projectID}`,
               JSON.stringify({
                 isFreshRemix: true,

--- a/www_src/pages/project/setdestination.js
+++ b/www_src/pages/project/setdestination.js
@@ -38,8 +38,8 @@ module.exports = {
         reportError('There was an error updating the element', err);
       }
 
-      if (window.Android) {
-        window.Android.goBack();
+      if (window.Platform) {
+        window.Platform.goBack();
       }
     });
   }

--- a/www_src/pages/tinker/tinker.jsx
+++ b/www_src/pages/tinker/tinker.jsx
@@ -42,7 +42,7 @@ var Tinker = React.createClass({
     this.load();
     this.props.update({
       onBackPressed: () => {
-        this.save(() => window.Android.goBack());
+        this.save(() => window.Platform.goBack());
       }
     });
   },
@@ -124,7 +124,7 @@ var Tinker = React.createClass({
         <div className="editor-flex-container">
           <div className="editor-preview">
             <PreviewComponent {...this.state.element} />
-            <button className="debug" onClick={this.save} hidden={window.Android}>DEBUG:SAVE</button>
+            <button className="debug" onClick={this.save} hidden={window.Platform}>DEBUG:SAVE</button>
           </div>
           <div className="color-preview">
             <code>color: {this.getEditorValue()};</code>

--- a/www_src/tests/api.test.js
+++ b/www_src/tests/api.test.js
@@ -21,11 +21,11 @@ function createMockXhr(routes) {
   }
 }
 
-// Mock window.Android,
+// Mock window.Platform,
 // re-require api with xhrMock if provided,
 // override uris so they're easier to target
 function resetMocks(xhrMock) {
-  global.window.Android = {
+  global.window.Platform = {
     getUserSession: function () {
       return {
         user: {

--- a/www_src/tests/router.test.js
+++ b/www_src/tests/router.test.js
@@ -22,7 +22,7 @@ describe('router', function () {
   describe('#getRouteParams', function () {
     beforeEach(resetAndroidApi);
 
-    it('should return test data when window.Android does not exist', function () {
+    it('should return test data when window.Platform does not exist', function () {
       router.android = null;
       should.deepEqual(router.getRouteParams(), {
         user: 1,
@@ -63,7 +63,7 @@ describe('router', function () {
   describe('#getRouteData', function () {
     beforeEach(resetAndroidApi);
 
-    it('should get return an empty object if no window.Android', function () {
+    it('should get return an empty object if no window.Platform', function () {
       router.android = null;
       should.deepEqual(router.getRouteData(), {});
     });
@@ -96,7 +96,7 @@ describe('router', function () {
   describe('#getUserSession', function () {
     beforeEach(resetAndroidApi);
 
-    it('should return test data if no window.Android', function () {
+    it('should return test data if no window.Platform', function () {
       router.android = null;
       should.deepEqual(router.getUserSession(),  {
         user: {
@@ -142,7 +142,7 @@ describe('router', function () {
         token: ''
       });
     });
-    it('should return appropriate test data if no window.Android', function () {
+    it('should return appropriate test data if no window.Platform', function () {
       router.android = null;
       should.deepEqual(router.getInitialState(), {
         params: router.getRouteParams(),


### PR DESCRIPTION
This PR *lightly* introduces a new module called `platform` that attempts to provide a browser polyfill for methods that are generally handled by Android. If the platform provides an interface bound to `window.Platform` it will return it rather than the polyfill. Because this has implications across the codebase, I'm only introducing this polyfill in a few areas for this PR:
- API request caching
- `discover.jsx`
- `make.jsx`
- `render.jsx`

The polyfill covers most of what we use today with a few notable gaps (listed in the lib as `@todo`):
- Camera / image gallery support
- Sharing panel support
- Route params