### PR TITLE
Fix crash/stall when entering color tinker mode.

### DIFF
--- a/www_src/components/color-spectrum/color-spectrum.jsx
+++ b/www_src/components/color-spectrum/color-spectrum.jsx
@@ -89,14 +89,28 @@ var RGB = React.createClass({
 });
 
 var ColorSpectrum = React.createClass({
+  getDefaultProps: function() {
+    return {
+      defaultColor: 'rgba(0, 0, 0, 0)'
+    };
+  },
   updateColor: function (color) {
     // Normalize any updates to rgba
     this.props.onChange(color.rgbaString());
   },
-  render: function () {
+  getColor: function(color, defaultColor) {
     // Convert raw color value to a Color instance
     // This way we can convert any format to hsb/rgba as needed
-    var color = Color(this.props.color);
+    try {
+      return Color(color);
+    } catch (e) {
+      // Our color was malformed or otherwise unspecified, so
+      // fall back to the default color.
+      return Color(defaultColor);
+    }
+  },
+  render: function () {
+    var color = this.getColor(this.props.color, this.props.defaultColor);
 
     return (<div>
       <div className="form-group" hidden={!this.props.HSB}>

--- a/www_src/tests/color-spectrum.test.js
+++ b/www_src/tests/color-spectrum.test.js
@@ -1,0 +1,24 @@
+var should = require('should');
+var React = require('react/addons');
+var ColorSpectrum = require('../components/color-spectrum/color-spectrum.jsx');
+
+describe('ColorSpectrum', function() {
+  it('does not throw when props.color is an empty string', function() {
+    var renderer = React.addons.TestUtils.createRenderer();
+    renderer.render(React.createElement(ColorSpectrum, {color: ''}));
+  });
+
+  describe("getColor()", function() {
+    var getColor = ColorSpectrum.prototype.getColor;
+
+    it('returns color if it is well-formed', function() {
+      getColor('rgba(255, 0, 0, 0)', 'rgba(0, 0, 0, 0)').rgbaString()
+        .should.eql('rgba(255, 0, 0, 0)');
+    });
+
+    it('returns default color if color is malformed', function() {
+      getColor('aweg', 'rgba(0, 0, 0, 0)').rgbaString()
+        .should.eql('rgba(0, 0, 0, 0)');
+    });
+  });
+});


### PR DESCRIPTION
This fixes #2297 by adding fault tolerance to the color tinker mode in the case when the color is an empty string or somehow malformed. It does this by falling back to a default color, which is `rgba(0, 0, 0, 0)` by default, but can easily be changed via a prop.

Adding tests for this was a bit funky because we don't appear to have any test suites that have a DOM. I can help with that if you need, as we have such a thing on teach and it's not very hard to set up. For now I've added a few tests using React's [shallow rendering](https://facebook.github.io/react/docs/test-utils.html#shallow-rendering) and other [workarounds](http://simonsmith.io/unit-testing-react-components-without-a-dom/#testing-component-methods).