### PR TITLE
Add JavaScript method to get the system locale

### DIFF
--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -22,6 +22,8 @@ import org.mozilla.webmaker.activity.Element;
 import org.mozilla.webmaker.router.Router;
 import org.mozilla.webmaker.storage.MemStorage;
 
+import java.util.Locale;
+
 public class WebAppInterface {
 
     protected Context mContext;
@@ -289,5 +291,15 @@ public class WebAppInterface {
     @JavascriptInterface
     public boolean isDebugBuild() {
         return BuildConfig.DEBUG;
+    }
+
+    /**
+     * ----------------------------------------
+     * Get System Locale
+     * ----------------------------------------
+     */
+    @JavascriptInterface
+    public String getSystemLocale() {
+        return Locale.getDefault().toString();
     }
 }


### PR DESCRIPTION
/cc @cadecairos @secretrobotron 

You can now use ```getSystemLocale()``` to return the default systems locale as a string format, ```<language>_<region>```. The end result should look like, ```en_US```.