### PR TITLE
Change locale response underscores to hypens

### DIFF
--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -299,7 +299,7 @@ public class WebAppInterface {
      * ----------------------------------------
      */
     @JavascriptInterface
-    public String getSystemLocale() {
-        return Locale.getDefault().toString();
+    public String getSystemLanguage() {
+        return Locale.getDefault().toString().replace("_", "-");
     }
 }

--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -300,6 +300,7 @@ public class WebAppInterface {
      */
     @JavascriptInterface
     public String getSystemLanguage() {
+        // Change underscores to dashes (The browser uses dashes instead)
         return Locale.getDefault().toString().replace("_", "-");
     }
 }


### PR DESCRIPTION
Output: https://gist.github.com/ryanw-se/9d2a241a1e68ba4ec5bb

This change was put in place because the browser uses dashes and not underscores like the result currently being outputted. 