### PR TITLE
Fixed webmaker-core dependency link

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/mozilla/webmaker-android/issues"
   },
   "dependencies": {
-    "webmaker-core": "https://github.com/mozilla/webmaker-core.git"
+    "webmaker-core": "git+https://github.com/mozilla/webmaker-core.git"
   },
   "homepage": "https://github.com/mozilla/webmaker-android",
   "devDependencies": {


### PR DESCRIPTION
Trying to `npm install` the package throws an ENOENT, because the link to the webmaker-core dependency is not recognized as a Git repository.

Changing the URI scheme to git+https:// fixes this.