### PR TITLE
Make "npm run build" work on Windows.

### DIFF
--- a/npm_tasks/explore.js
+++ b/npm_tasks/explore.js
@@ -1,0 +1,34 @@
+// This is meant to provide a cross-platform way of doing the same thing
+// as "npm explore <name> -- <cmd>" (which doesn't work on Windows; see
+// https://github.com/npm/npm/issues/8932).
+//
+// Note that <cmd> is expected to be something extremely simple like
+// "npm install" or "git pull origin master". It shouldn't contain any
+// quoted arguments or other funky things.
+
+var fs = require('fs');
+var path = require('path');
+var execSync = require('child_process').execSync;
+
+var ROOT_DIR = path.resolve(__dirname, '..');
+
+function getModuleDir(moduleName) {
+  return fs.realpathSync(path.resolve(ROOT_DIR, 'node_modules', moduleName));
+}
+
+function explore(moduleName, cmd) {
+  execSync(cmd, { cwd: getModuleDir(moduleName), stdio: 'inherit' });
+}
+
+function main() {
+  if (process.argv.length < 5 || process.argv[3] != '--') {
+    console.log("usage: " + path.basename(process.argv[1]) +
+                " <name> -- <cmd>");
+    process.exit(1);
+  }
+  explore(process.argv[2], process.argv.slice(4).join(' '));
+}
+
+if (!module.parent) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Webmaker for Android.",
   "scripts": {
     "start": "npm run build",
-    "build": "npm explore webmaker-core -- npm install && npm run copy:env && npm run build:core && npm run copy:core",
-    "build:core": "npm explore webmaker-core -- npm run build",
+    "build": "node npm_tasks/explore.js webmaker-core -- npm install && npm run copy:env && npm run build:core && npm run copy:core",
+    "build:core": "node npm_tasks/explore.js webmaker-core -- npm run build",
     "copy:core": "rimraf app/src/main/assets/www/ && mkdirp app/src/main/assets/www/ && ncp node_modules/webmaker-core/dest/ app/src/main/assets/www/",
     "copy:env": "node npm_tasks/copy-env.js"
   },


### PR DESCRIPTION
This fixes mozilla/webmaker-core#297 in a way slightly different from https://github.com/mozilla/webmaker-browser/pull/164: it adds a very limited drop-in replacement for `npm explore <name> -- <cmd>` at `npm_tasks/explore.js` that works on Windows. I did this because webmaker-android's `package.json` uses `npm explore` for multiple tasks. It also makes it easier to migrate back to a pure npm solution if/when https://github.com/npm/npm/issues/8932 is fixed.

If we really like this solution, we can potentially use it in webmaker-browser too, and use any of a variety of mechanisms to ensure we stay DRY.
