### PR TITLE
Add NPM tasks to gradle build files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.moowork.node'
 
 android {
     compileSdkVersion 22
@@ -52,6 +53,10 @@ android {
     }
 }
 
+task npmRunBuild (type: NpmTask) {
+    args = ['run', 'build']
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -66,3 +71,12 @@ dependencies {
     compile 'com.google.android.gms:play-services-analytics:7.5.0'
     compile 'org.xwalk:xwalk_core_library:13.42.319.12'
 }
+
+node {
+    version = '0.12.2'
+    npmVersion = '2.7.4'
+    distBaseUrl = 'http://nodejs.org/dist'
+    download = true
+}
+
+preBuild.dependsOn npmRunBuild

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
     }
 }
 
-task npmRunBuild (type: NpmTask) {
+task npmRunBuild (type: NpmTask, dependsOn: ['npmInstall']) {
     args = ['run', 'build']
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,14 +28,14 @@ android {
 
     productFlavors {
         x86 {
-            flavorDimension "abi"
+            dimension "abi"
             ndk {
                 abiFilters "x86", ""
             }
             versionCode = 3
         }
         armv7 {
-            flavorDimension "abi"
+            dimension "abi"
             ndk {
                 abiFilters "armeabi-v7a", ""
             }
@@ -62,7 +62,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-v13:22.1.1'
-    compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.google.android.gms:play-services-analytics:7.3.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.google.android.gms:play-services-analytics:7.5.0'
     compile 'org.xwalk:xwalk_core_library:13.42.319.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,33 +2,15 @@
 
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.moowork.gradle:gradle-node-plugin:0.10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
-}
-
-plugins {
-  id 'com.moowork.node' version '0.9'
-}
-
-node {
-    version = '0.12.2'
-    npmVersion = '2.7.4'
-    distBaseUrl = 'http://nodejs.org/dist'
-    download = true
-}
-
-allprojects {
-    repositories {
-        jcenter()
-    }
-}
-
-task preBuild (type: NpmTask) {
-    args = ['run', 'build']
 }


### PR DESCRIPTION
Adds the command ```npm run build``` to the gradle build files to run before the app is actually compiled. 

It also runs the command ```npm install``` if it has never been ran before, or if changes have been made to the ```package.json``` file or ```node_modules```.

Closes mozilla/webmaker-core#365, mozilla/webmaker-core#281, mozilla/webmaker-core#276

/cc @thisandagain 