### PR TITLE
Add isNetworkAvailable method [mozilla/webmaker-core#433]

### DIFF
--- a/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/javascript/WebAppInterface.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
 import android.util.Log;
 
@@ -303,4 +305,18 @@ public class WebAppInterface {
         // Change underscores to dashes (The browser uses dashes instead)
         return Locale.getDefault().toString().replace("_", "-");
     }
+
+    /**
+     * ----------------------------------------
+     * Determine network availability
+     * ----------------------------------------
+     */
+    @JavascriptInterface
+    public boolean isNetworkAvailable() {
+        ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+
+        return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+    }
+
 }


### PR DESCRIPTION
Although https://gist.github.com/thisandagain/0257dec9f36b376e36c2 would work it still relies on api.webmaker.org being up/available.

I saw this documented here: http://developer.android.com/training/monitoring-device-state/connectivity-monitoring.html#DetermineConnection, and it seems to work fine. What do you think @thisandagain?