### PR TITLE
Add JS Interface for setting activity title, Closes mozilla/webmaker-core#285

### DIFF
--- a/app/src/main/java/org/mozilla/webmaker/web/javascript/WebAppInterface.java
+++ b/app/src/main/java/org/mozilla/webmaker/web/javascript/WebAppInterface.java
@@ -214,6 +214,24 @@ public class WebAppInterface {
 
     /**
      * ---------------------------------------
+     * Setting the activity action bar title.
+     * ---------------------------------------
+     */
+
+    @JavascriptInterface
+    public void setTitle(final String title) {
+        final Activity activity = mActivity;
+        if (activity == null) return;
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                activity.setTitle(title);
+            }
+        });
+    }
+
+    /**
+     * ---------------------------------------
      * Router
      * ---------------------------------------
      */


### PR DESCRIPTION
Allows us to set the activity title, via the action bar title. Adds a new function called setTitle().

Closes mozilla/webmaker-core#285

R? @k88hudson @xmatthewx @Pomax 