### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install
 
 #### Specifying a dev environment
 
-In order to override default `webmaker-core` settings such as `id` and `api` endpoints, create an `.env` file in the webmaker-android root directory, and declare any enviroment overrides you need in that file, then (re)build the webmaker-android project using `npm run build`.
+In order to override default `webmaker-core` settings such as `id` and `api` endpoints, create an `.env` file in the webmaker-android root directory, and declare any environment overrides you need in that file, then (re)build the webmaker-android project using `npm run build`.
 
 For example, to run webmaker-android with a different API endpoint, you would make sure the `.env` file contains:
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example, to run webmaker-android with a different API endpoint, you would ma
 API_URI=http://alternative.api.endpoint
 ```
 
-For more details on which environment variables are used by webmaker-core, please see the [webmaker-core default enviroment](https://github.com/mozilla/webmaker-core/blob/develop/config/defaults.env).
+For more details on which environment variables are used by webmaker-core, please see the [webmaker-core default environment](https://github.com/mozilla/webmaker-core/blob/develop/config/defaults.env).
 
 #### Android
 


### PR DESCRIPTION
Changed 'enviroment' to 'environment' in the section 'Specifying a dev environment'.
